### PR TITLE
Improve graftegner settings layout for small screens

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -20,20 +20,20 @@
     .ui{display:flex;flex-direction:column;gap:10px;margin-bottom:12px}
 
     /* Rad 1: f1, dom1, punkter */
-    .row.fn1{display:grid;grid-template-columns: 260px 260px 140px;gap:10px}
+    .row.fn1{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:10px}
     /* Rad 2: f2, dom2 */
-    .row.fn2{display:grid;grid-template-columns: 260px 260px;gap:10px}
+    .row.fn2{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:10px}
     /* Rad 3: screen */
-    .row.single{display:grid;grid-template-columns: 420px;gap:10px}
+    .row.single{display:grid;grid-template-columns:minmax(200px,1fr);gap:10px}
     /* Rad 4: akse-navn etter screen */
-    .row.axes{display:grid;grid-template-columns: 120px 120px;gap:10px}
+    .row.axes{display:grid;grid-template-columns:repeat(auto-fit,minmax(100px,1fr));gap:10px}
 
     label{font-size:12px;color:var(--muted);display:block;margin-bottom:4px}
     input[type="text"],select{
-      width:100%;padding:9px 12px;border-radius:10px;border:1px solid #e5e7eb;background:#fff;
-      box-shadow:0 1px 2px rgba(0,0,0,.03) inset;font-size:14px
+      width:100%;padding:6px 8px;border-radius:8px;border:1px solid #e5e7eb;background:#fff;
+      box-shadow:0 1px 2px rgba(0,0,0,.03) inset;font-size:13px
     }
-    .select-compact{max-width:72px;padding:6px 8px;font-size:13px;height:34px}
+    .select-compact{max-width:64px;padding:4px 6px;font-size:12px;height:32px}
 
     .actions{display:flex;gap:10px;margin-top:2px;flex-wrap:wrap}
     button{
@@ -41,13 +41,6 @@
       box-shadow:0 2px 10px rgba(0,0,0,.06);cursor:pointer;font-weight:600
     }
     button:active{transform:translateY(1px)}
-
-    @media (max-width:820px){
-      .row.fn1{grid-template-columns: 1fr}
-      .row.fn2{grid-template-columns: 1fr}
-      .row.single{grid-template-columns: 1fr}
-      .row.axes{grid-template-columns: 1fr 1fr}
-    }
   </style>
 </head>
 <body>


### PR DESCRIPTION
## Summary
- Make settings grid responsive with auto-fit columns to adapt better to smaller screens
- Reduce input padding and select sizes for more compact text boxes

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c03cb54b708324b2ddcccfc2d2d163