### PR TITLE
Align graftegner layout with nkant

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="no">
 <head>
   <meta charset="utf-8" />
@@ -10,108 +10,119 @@
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
 
   <style>
-    :root { --bg:#f7f7f9; --ink:#1f2937; --muted:#6b7280; --card:#ffffff; }
-    html,body{height:100%}
-    body{margin:0;background:var(--bg);color:var(--ink);font-family:system-ui,-apple-system,"Segoe UI",Roboto,Arial,sans-serif}
-    .wrap{max-width:1200px;margin:auto;padding:16px}
-    .board-shell{background:var(--card);border-radius:14px;box-shadow:0 8px 24px rgba(0,0,0,.08);padding:10px}
-    #board{width:100%;height:min(70vh,780px);border-radius:10px}
-
-    .ui{display:flex;flex-direction:column;gap:10px;margin-bottom:12px}
-
-    /* Rad 1: f1, dom1, punkter */
-    .row.fn1{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:10px}
-    /* Rad 2: f2, dom2 */
-    .row.fn2{display:grid;grid-template-columns:repeat(auto-fit,minmax(200px,1fr));gap:10px}
-    /* Rad 3: screen */
-    .row.single{display:grid;grid-template-columns:minmax(200px,1fr);gap:10px}
-    /* Rad 4: akse-navn etter screen */
-    .row.axes{display:grid;grid-template-columns:repeat(auto-fit,minmax(100px,1fr));gap:10px}
-
-    label{font-size:12px;color:var(--muted);display:block;margin-bottom:4px}
-    input[type="text"],select{
-      width:100%;padding:6px 8px;border-radius:8px;border:1px solid #e5e7eb;background:#fff;
-      box-shadow:0 1px 2px rgba(0,0,0,.03) inset;font-size:13px
+    :root { --gap: 18px; }
+    html,body { height: 100%; }
+    body {
+      margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
+      color: #111827; background: #f7f8fb; padding: 20px;
     }
-    .select-compact{max-width:64px;padding:4px 6px;font-size:12px;height:32px}
-
-    .actions{display:flex;gap:10px;margin-top:2px;flex-wrap:wrap}
-    button{
-      appearance:none;border:0;border-radius:10px;background:#fff;padding:10px 16px;
-      box-shadow:0 2px 10px rgba(0,0,0,.06);cursor:pointer;font-weight:600
+    .wrap { max-width: 1200px; margin: 0 auto; }
+    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
+    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
+    .card {
+      background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
+      box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 14px; display: flex;
+      flex-direction: column; gap: 10px;
     }
-    button:active{transform:translateY(1px)}
+    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
+    .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
+    .figure #board { width: 100%; height: min(70vh,780px); display: block; }
+    .toolbar { display: flex; gap: 10px; justify-content: flex-end; flex-wrap: wrap; }
+    .btn {
+      appearance: none; border: 1px solid #d1d5db; background: #fff; border-radius: 10px;
+      padding: 8px 12px; font-size: 14px; cursor: pointer;
+      transition: box-shadow .2s, transform .02s;
+    }
+    .btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
+    .btn:active { transform: translateY(1px); }
+    label { font-size: 13px; color: #4b5563; }
+    input[type="text"], select {
+      border: 1px solid #d1d5db; border-radius: 10px; padding: 8px 10px;
+      font-size: 14px; background: #fff; width: 100%; box-sizing: border-box;
+    }
+    .small { font-size: 12px; color: #6b7280; }
+    .ui { display: flex; flex-direction: column; gap: 10px; }
+    .row.fn1 { display: grid; grid-template-columns: repeat(auto-fit,minmax(200px,1fr)); gap: 10px; }
+    .row.fn2 { display: grid; grid-template-columns: repeat(auto-fit,minmax(200px,1fr)); gap: 10px; }
+    .row.single { display: grid; grid-template-columns: minmax(200px,1fr); gap: 10px; }
+    .row.axes { display: grid; grid-template-columns: repeat(auto-fit,minmax(100px,1fr)); gap: 10px; }
+    .select-compact { max-width: 64px; padding: 4px 6px; font-size: 12px; height: 32px; }
   </style>
 </head>
 <body>
-<div class="wrap">
+  <div class="wrap">
+    <div class="grid">
 
-  <div class="ui" id="uiOverrides">
+      <div class="card">
+        <h2>Graf</h2>
+        <div class="figure"><div id="board"></div></div>
+        <div class="toolbar">
+          <button id="btnApply" class="btn" type="button">Tegn</button>
+          <button id="btnReset" class="btn" type="button">Nullstill zoom/pan</button>
+          <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+        </div>
+      </div>
 
-    <!-- Rad 1: f1 + dom1 + punkter -->
-    <div class="row fn1">
-      <div>
-        <label for="fn1">Funksjon 1</label>
-        <input id="fn1" type="text" value="f(x)=x^2-2">
-      </div>
-      <div>
-        <label for="dom1">Definisjonsmengde funksjon 1 (Valgfritt. Skriv [start, stopp])</label>
-        <input id="dom1" type="text" placeholder="">
-      </div>
-      <div>
-        <label for="pointsCount">Punkter (På funksjon 1)</label>
-        <select id="pointsCount" class="select-compact">
-          <option value="0" selected>0</option>
-          <option value="1">1</option>
-          <option value="2">2</option>
-        </select>
-      </div>
-    </div>
+      <div class="card">
+        <h2>Innstillinger</h2>
+        <div class="ui" id="uiOverrides">
+          <!-- Rad 1: f1 + dom1 + punkter -->
+          <div class="row fn1">
+            <div>
+              <label for="fn1">Funksjon 1</label>
+              <input id="fn1" type="text" value="f(x)=x^2-2">
+            </div>
+            <div>
+              <label for="dom1">Definisjonsmengde funksjon 1 (Valgfritt. Skriv [start, stopp])</label>
+              <input id="dom1" type="text" placeholder="">
+            </div>
+            <div>
+              <label for="pointsCount">Punkter (På funksjon 1)</label>
+              <select id="pointsCount" class="select-compact">
+                <option value="0" selected>0</option>
+                <option value="1">1</option>
+                <option value="2">2</option>
+              </select>
+            </div>
+          </div>
 
-    <!-- Rad 2: f2 + dom2 -->
-    <div class="row fn2">
-      <div>
-        <label for="fn2">Funksjon 2 (valgfritt)</label>
-        <input id="fn2" type="text" placeholder="">
-      </div>
-      <div>
-        <label for="dom2">Definisjonsmengde funksjon 2 (Valgfritt. Skriv [start, stopp])</label>
-        <input id="dom2" type="text" placeholder="">
-      </div>
-    </div>
+          <!-- Rad 2: f2 + dom2 -->
+          <div class="row fn2">
+            <div>
+              <label for="fn2">Funksjon 2 (valgfritt)</label>
+              <input id="fn2" type="text" placeholder="">
+            </div>
+            <div>
+              <label for="dom2">Definisjonsmengde funksjon 2 (Valgfritt. Skriv [start, stopp])</label>
+              <input id="dom2" type="text" placeholder="">
+            </div>
+          </div>
 
-    <!-- Rad 3: Screen -->
-    <div class="row single">
-      <div>
-        <label for="screen">Screen (Overstyrer autozoom hvis satt. Skriv minX, maksX, minY, maksY)</label>
-        <input id="screen" type="text" placeholder="">
-      </div>
-    </div>
+          <!-- Rad 3: Screen -->
+          <div class="row single">
+            <div>
+              <label for="screen">Screen (Overstyrer autozoom hvis satt. Skriv minX, maksX, minY, maksY)</label>
+              <input id="screen" type="text" placeholder="">
+            </div>
+          </div>
 
-    <!-- Rad 4: Aksenavn – smalere felt -->
-    <div class="row axes">
-      <div>
-        <label for="axisXLabel">Navn på x-akse (valgfritt)</label>
-        <input id="axisXLabel" type="text" value="x">
+          <!-- Rad 4: Aksenavn – smalere felt -->
+          <div class="row axes">
+            <div>
+              <label for="axisXLabel">Navn på x-akse (valgfritt)</label>
+              <input id="axisXLabel" type="text" value="x">
+            </div>
+            <div>
+              <label for="axisYLabel">Navn på y-akse (valgfritt)</label>
+              <input id="axisYLabel" type="text" value="y">
+            </div>
+          </div>
+        </div>
       </div>
-      <div>
-        <label for="axisYLabel">Navn på y-akse (valgfritt)</label>
-        <input id="axisYLabel" type="text" value="y">
-      </div>
-    </div>
 
-    <div class="actions">
-      <button id="btnApply">Tegn</button>
-      <button id="btnReset">Nullstill zoom/pan</button>
-      <button id="btnSvg">Last ned SVG</button>
     </div>
   </div>
 
-  <div class="board-shell">
-    <div id="board"></div>
-  </div>
-</div>
-
-<script src="graftegner.js"></script>
+  <script src="graftegner.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- restructure graftegner layout with responsive grid and card components
- move graph controls into toolbar and settings into right-hand panel

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c04ba8f22c832482abc59894336936