### PR TITLE
Remove advanced config section from Nkant settings

### DIFF
--- a/nkant.html
+++ b/nkant.html
@@ -54,20 +54,6 @@
         <textarea id="inpSpecs" rows="4" spellcheck="false">a=3, b=5, c=5
 a=5, b=5, c=5, d=5, B=90</textarea>
         <div class="small">Eksempler: "a=3, b=5, c=4" (trekant), "a=5, b=5, c=5, d=5, B=90" (firkant – må ha d og én vinkel A/B/C/D).</div>
-
-        <label for="advConfig">ADV CONFIG (JSON)</label>
-        <textarea id="advConfig" rows="6" spellcheck="false">{
-  "angle": {
-    "factor": 0.28,
-    "min": 18,
-    "max": 60,
-    "insideK": { "right": 1.5, "other": 1.5 },
-    "outsideK": { "right": 0.5, "other": 0.50 },
-    "outsidePad": 0,
-    "outsideMaxFactor": 0.90,
-    "outsideMin": 6
-  }
-}</textarea>
         <div class="sep"></div>
 
         <!-- Figur 1 -->

--- a/nkant.js
+++ b/nkant.js
@@ -555,7 +555,6 @@ function bindUI(){
   const btnSvg = $("#btnSvg");
   const btnPng = $("#btnPng");
   const btnReset = $("#btnReset");
-  const inpAdv = $("#advConfig");
 
   const f1Sides=$("#f1Sides"), f1Angles=$("#f1Angles");
   const f2Sides=$("#f2Sides"), f2Angles=$("#f2Angles");
@@ -587,10 +586,6 @@ function bindUI(){
   // init
   DEFAULT_SPECS = inpSpecs?.value || "";
   STATE.specsText = DEFAULT_SPECS;
-  if(inpAdv){
-    try{ deepAssign(ADV_CONFIG, JSON.parse(inpAdv.value)); }catch(_){ }
-    inpAdv.addEventListener("input", ()=>{ try{ deepAssign(ADV_CONFIG, JSON.parse(inpAdv.value)); renderCombined(); }catch(_){ }});
-  }
 
   inpSpecs.value = STATE.specsText;
   f1Sides.value  = STATE.fig1.sides.default;


### PR DESCRIPTION
## Summary
- Drop ADV CONFIG (JSON) section from nKant settings page
- Clean up JavaScript to remove handling for ADV CONFIG textarea

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0591453388324aa2f701dc19be6b2