### PR TITLE
Add settings UI for Tenkeblokker

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -25,10 +25,21 @@
     .tb-stepper button{width:64px;height:48px;border:0;background:#fff;font-size:28px;cursor:pointer}
     .tb-stepper button:active{transform:translateY(1px)}
     .tb-divider{width:1px;height:36px;background:#d6d6e3;margin:0 6px}
+    #settings{margin-bottom:16px}
+    #settings label{display:block;margin:4px 0}
+    #settings input{width:4rem;margin-left:8px}
   </style>
 </head>
 <body>
   <div class="tb-wrap">
+    <details id="settings">
+      <summary>⚙️ Innstillinger</summary>
+      <label>Totalt<input id="cfg-total" type="number" min="1"></label>
+      <label>Start blokker<input id="cfg-startN" type="number" min="1"></label>
+      <label>Fylte blokker<input id="cfg-startK" type="number" min="0"></label>
+      <label>Min blokker<input id="cfg-minN" type="number" min="1"></label>
+      <label>Maks blokker<input id="cfg-maxN" type="number" min="1"></label>
+    </details>
     <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker"></svg>
 
     <div class="tb-stepper" aria-label="Antall blokker">

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -16,7 +16,7 @@ const ADV = {
 };
 
 /* ============ DERIVERT KONFIG FOR RENDER (IKKE REDIGER) ============ */
-const CFG = {
+let CFG = {
   total: SIMPLE.total,
   minN: SIMPLE.minN,
   maxN: SIMPLE.maxN,
@@ -49,9 +49,7 @@ const gBrace  = add('g');     // parentes + TOTAL
 addTo(gBase ,'rect',{x:L,y:TOP,width:R-L,height:BOT-TOP,class:'tb-rect-empty'});
 addTo(gFrame,'rect',{x:L,y:TOP,width:R-L,height:BOT-TOP,class:'tb-frame'});
 
-// Firkantparentes + total
-drawBracketSquare(L, R, BRACE_Y, CFG.bracketTick);
-addTo(gBrace,'text',{x:(L+R)/2, y:BRACE_Y - CFG.labelOffsetY, class:'tb-total'}).textContent = CFG.total;
+// Firkantparentes + total tegnes i applyConfig()
 
 // Håndtak
 const handleShadow = addTo(gHandle,'circle',{cx:R, cy:(TOP+BOT)/2+2, r:20, class:'tb-handle-shadow'});
@@ -118,6 +116,21 @@ function drawBracketSquare(x0, x1, y, tick){
   gBrace.appendChild(path);
 }
 
+function applyConfig(){
+  CFG = {
+    total: SIMPLE.total,
+    minN: SIMPLE.minN,
+    maxN: SIMPLE.maxN,
+    bracketTick: ADV.bracketTick,
+    labelOffsetY: ADV.labelOffsetY
+  };
+  n = clamp(SIMPLE.startN, CFG.minN, CFG.maxN);
+  k = clamp(SIMPLE.startK, 0, n);
+  drawBracketSquare(L, R, BRACE_Y, CFG.bracketTick);
+  addTo(gBrace,'text',{x:(L+R)/2, y:BRACE_Y - CFG.labelOffsetY, class:'tb-total'}).textContent = CFG.total;
+  redraw();
+}
+
 // ---------- Tegning ----------
 function redraw(){
   gFill.innerHTML = '';
@@ -159,5 +172,36 @@ function setK(next){
   redraw();
 }
 
+function setupSettingsUI(){
+  const totalInput = document.getElementById('cfg-total');
+  const nInput = document.getElementById('cfg-startN');
+  const kInput = document.getElementById('cfg-startK');
+  const minInput = document.getElementById('cfg-minN');
+  const maxInput = document.getElementById('cfg-maxN');
+  if(!totalInput || !nInput || !kInput || !minInput || !maxInput) return;
+
+  totalInput.value = SIMPLE.total;
+  nInput.value = SIMPLE.startN;
+  kInput.value = SIMPLE.startK;
+  minInput.value = SIMPLE.minN;
+  maxInput.value = SIMPLE.maxN;
+
+  function update(){
+    SIMPLE.total = parseInt(totalInput.value) || SIMPLE.total;
+    SIMPLE.startN = parseInt(nInput.value) || SIMPLE.startN;
+    SIMPLE.startK = parseInt(kInput.value) || SIMPLE.startK;
+    SIMPLE.minN = parseInt(minInput.value) || SIMPLE.minN;
+    SIMPLE.maxN = parseInt(maxInput.value) || SIMPLE.maxN;
+    applyConfig();
+  }
+
+  totalInput.addEventListener('change', update);
+  nInput.addEventListener('change', update);
+  kInput.addEventListener('change', update);
+  minInput.addEventListener('change', update);
+  maxInput.addEventListener('change', update);
+}
+
 // init
-redraw();
+setupSettingsUI();
+applyConfig();


### PR DESCRIPTION
## Summary
- add HTML settings panel for Tenkeblokker to tweak total, start blocks, and bounds
- wire up configuration with applyConfig and setupSettingsUI in JS

## Testing
- `node --check tenkeblokker.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c05d0c08f48324ad2bd0a194a8ab07