### PR TITLE
Add bar locking option and render bars with black lines

### DIFF
--- a/diagram.html
+++ b/diagram.html
@@ -49,7 +49,7 @@
     .yLabel{fill:#333;font-size:18px}
 
     /* Søyler + vurderingsrammer */
-    .bar{fill:#7c3aed;fill-opacity:1;opacity:1}
+    .bar{fill:none;stroke:#000;stroke-width:4}
     .bar.badge-ok{stroke:#2e7d32;stroke-width:4}
     .bar.badge-no{stroke:#c62828;stroke-width:4}
 
@@ -61,9 +61,8 @@
     .value{fill:#111;font-size:16px;text-anchor:middle;paint-order:stroke fill;stroke:#fff;stroke-width:6;pointer-events:none}
 
     /* Låsing */
-    .bar.locked{fill:#d1d5db;cursor:not-allowed}
+    .bar.locked{cursor:not-allowed}
     .handle.locked{fill:#e5e7eb;cursor:not-allowed}
-    .lock{cursor:pointer;font-size:20px;user-select:none}
 
     /* Fokus + tastatur (A11y-overlay) */
     .a11y{cursor:ns-resize;fill:transparent;stroke:none}
@@ -117,6 +116,9 @@
           </label>
           <label>Toleranse
             <input id="cfgTolerance" type="text" value="0">
+          </label>
+          <label>Fjern håndtak (0/1, kommaseparert)
+            <input id="cfgLocked" type="text" value="">
           </label>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- Add `locked` configuration and settings input to remove handles from selected bars
- Render bars as solid black strokes instead of translucent purple
- Omit padlock icons and hide handles on locked bars

## Testing
- `node --check diagram.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0a63007a4832486f0b5955182e3f5