### PR TITLE
Scale area model B SVG within card

### DIFF
--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -159,10 +159,8 @@ function render(){
   set(svg, "viewBox", `0 0 ${VBW} ${VBH}`);
   set(svg, "preserveAspectRatio", "xMidYMid meet");
   Object.assign(svg.style, {
-    width: "100vw",
-    height: "auto",
     maxHeight: (ADV.fit?.maxVh ?? 100) + "vh",
-    maxWidth:  (ADV.fit?.maxVw ?? 100) + "vw",
+    maxWidth: "100%",
     display: "block",
     touchAction: "none"
   });
@@ -329,11 +327,15 @@ function render(){
   // ---- Responsiv skalering ----
   function fitToViewport(){
     const SAFE = ADV.fit?.safePad || {top:8,right:8,bottom:64,left:8};
-    const availW = Math.max(100, window.innerWidth  - (SAFE.left + SAFE.right));
+    const availW = Math.max(100, svg.parentElement.clientWidth - (SAFE.left + SAFE.right));
     const availH = Math.max(100, window.innerHeight - (SAFE.top  + SAFE.bottom));
     const s = Math.min(availW / VBW, availH / VBH);
-    svg.setAttribute("width",  VBW * s);
-    svg.setAttribute("height", VBH * s);
+    const w = VBW * s;
+    const h = VBH * s;
+    svg.setAttribute("width",  w);
+    svg.setAttribute("height", h);
+    svg.style.width = w + "px";
+    svg.style.height = h + "px";
     refreshSvgRect();
   }
 


### PR DESCRIPTION
## Summary
- compute SVG width based on its container so both model and settings fit side by side

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ac2baac48324a0cffe6476587b98