### PR TITLE
fix: restore ES5 compatibility

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -318,21 +318,21 @@ function rebuildFunctionSegmentsFor(g){
   var eps=(R-L)*1e-6;
   function safe(x){ var y; try{y=g.fn(x);}catch(_){y=NaN;} return isFinite(y)?y:NaN; }
   g.segs=[];
-  for (let i=0; i<xs.length-1; i++) {
-    let a = xs[i], b = xs[i+1];
-    const leftOpen = (i > 0), rightOpen = (i < xs.length-2);
-    if (leftOpen) a += eps;
-    if (rightOpen) b -= eps;
-    if (b <= a) continue;
-    // Use numeric bounds for each segment to avoid capturing mutable
-    // variables in closures, which could cause the graph to disappear
-    // when the view changes.
-    const seg = brd.create(
-      "functiongraph",
-      [safe, a, b],
-      { strokeColor: g.color, strokeWidth: 4, fixed: true, highlight: false, visible: true }
-    );
-    g.segs.push(seg);
+  for (var i=0; i<xs.length-1; i++) {
+    (function(a, b, leftOpen, rightOpen){
+      if (leftOpen) { a += eps; }
+      if (rightOpen) { b -= eps; }
+      if (b <= a) { return; }
+      // Use numeric bounds for each segment to avoid capturing mutable
+      // variables in closures, which could cause the graph to disappear
+      // when the view changes.
+      var seg = brd.create(
+        "functiongraph",
+        [safe, a, b],
+        { strokeColor: g.color, strokeWidth: 4, fixed: true, highlight: false, visible: true }
+      );
+      g.segs.push(seg);
+    })(xs[i], xs[i+1], i > 0, i < xs.length-2);
   }
 }
 function updateAllBrackets(){


### PR DESCRIPTION
## Summary
- ensure function graph segments work in older ES5 environments by replacing let/const with var and an IIFE

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c0adb6720c8324992ebc74e2035a8d