### PR TITLE
Fix Arealmodell grid line opacity

### DIFF
--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -40,7 +40,7 @@
 
     .outer { fill: none; stroke: #333; stroke-width: 3.5; }
     .split { stroke: #333; stroke-width: 2.5; }
-    .grid  { stroke: #000; stroke-width: 0.8; opacity: .35; }
+    svg .grid line { stroke: #000; stroke-width: 0.8; stroke-opacity: .35; }
     .handle { fill: #ecebf6; stroke: #333; stroke-width: 2; cursor: grab; }
     .handle:active { cursor: grabbing; }
 


### PR DESCRIPTION
## Summary
- prevent Arealmodell B page from becoming translucent by scoping grid-line styles to SVG

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c0afbac41c83249c1922f4a1d645ea