### PR TITLE
Refine think blocks UI and fraction display

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -57,13 +57,14 @@
       background:#fff;
       box-shadow:0 6px 24px rgba(0,0,0,.08);
       overflow:hidden;
+      margin:0 auto;
     }
     .tb-stepper button{
-      width:64px;
-      height:48px;
+      width:40px;
+      height:40px;
       border:0;
       background:#fff;
-      font-size:28px;
+      font-size:24px;
       cursor:pointer;
     }
     .tb-stepper button:active{transform:translateY(1px)}
@@ -83,7 +84,6 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <h2>Tenkeblokker</h2>
         <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker"></svg>
 
         <div class="tb-stepper" aria-label="Fylte blokker">

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -108,8 +108,6 @@ function clamp(v,a,b){ return Math.max(a, Math.min(b,v)); }
 function fmt(x){ return (Math.round(x*100)/100).toString().replace('.',','); }
 function fmtVal(per){
   switch(CFG.valMode){
-    case 'fraction':
-      return `1/${n}`;
     case 'percent':
       return fmt(100/n) + ' %';
     case 'exact':
@@ -118,6 +116,13 @@ function fmtVal(per){
     default:
       return fmt(per);
   }
+}
+
+function addFractionVal(cx, cy, num, den){
+  const lineW = 28;
+  addTo(gVals,'text',{x:cx, y:cy-18, class:'tb-val'}).textContent = num;
+  addTo(gVals,'line',{x1:cx-lineW/2, y1:cy, x2:cx+lineW/2, y2:cy, stroke:'#111', 'stroke-width':2});
+  addTo(gVals,'text',{x:cx, y:cy+18, class:'tb-val'}).textContent = den;
 }
 
 // Skjerm-px → SVG viewBox-koordinater
@@ -233,11 +238,19 @@ function redraw(){
   }
   // verdier i fylte celler
   const per = CFG.total / n;
-  const valText = fmtVal(per);
-  for(let i=0;i<k;i++){
-    const cx = L + (i+0.5)*cellW;
-    const cy = (TOP+BOT)/2;
-    addTo(gVals,'text',{x:cx,y:cy,class:'tb-val'}).textContent = valText;
+  if(CFG.valMode === 'fraction'){
+    for(let i=0;i<k;i++){
+      const cx = L + (i+0.5)*cellW;
+      const cy = (TOP+BOT)/2;
+      addFractionVal(cx, cy, 1, n);
+    }
+  } else {
+    const valText = fmtVal(per);
+    for(let i=0;i<k;i++){
+      const cx = L + (i+0.5)*cellW;
+      const cy = (TOP+BOT)/2;
+      addTo(gVals,'text',{x:cx,y:cy,class:'tb-val'}).textContent = valText;
+    }
   }
   // håndtak-pos
   const hx = L + k*cellW;


### PR DESCRIPTION
## Summary
- shrink and center plus/minus controls for think blocks
- remove redundant Tenkeblokker heading
- render fraction values with a proper fraction bar

## Testing
- `npm test` (fails: Error: no test specified)
- `node --check tenkeblokker.js`


------
https://chatgpt.com/codex/tasks/task_e_68c0c0a9ed508324b2c7504e8f060ff2