### PR TITLE
Make stepper control block count in Tenkeblokker

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -86,10 +86,10 @@
       <div class="card">
         <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker"></svg>
 
-        <div class="tb-stepper" aria-label="Fylte blokker">
-          <button id="tbMinus" type="button" aria-label="Færre fylte blokker">−</button>
+        <div class="tb-stepper" aria-label="Blokker">
+          <button id="tbMinus" type="button" aria-label="Færre blokker">−</button>
           <div class="tb-divider"></div>
-          <button id="tbPlus"  type="button" aria-label="Flere fylte blokker">+</button>
+          <button id="tbPlus"  type="button" aria-label="Flere blokker">+</button>
         </div>
 
         <div class="tb-toolbar">

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -67,8 +67,8 @@ const btnSvg       = document.getElementById('btnSvg');
 const btnPng       = document.getElementById('btnPng');
 
 // ---------- Interaksjon ----------
-document.getElementById('tbMinus').addEventListener('click', ()=> setK(k-1));
-document.getElementById('tbPlus') .addEventListener('click', ()=> setK(k+1));
+document.getElementById('tbMinus').addEventListener('click', ()=> setN(n-1));
+document.getElementById('tbPlus') .addEventListener('click', ()=> setN(n+1));
 btnSvg?.addEventListener('click', ()=> downloadSVG(svg, 'tenkeblokker.svg'));
 btnPng?.addEventListener('click', ()=> downloadPNG(svg, 'tenkeblokker.png', 2));
 


### PR DESCRIPTION
## Summary
- Shift plus/minus stepper to modify the denominator (block count) rather than the number of filled blocks.
- Update stepper accessibility labels to match its new purpose.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c116e8c8748324a4f7ec2500caddff