### PR TITLE
Refactor Arealmodell A settings layout

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -3,61 +3,94 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Arealmodell 0</title>
+  <title>Arealmodell A</title>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css" />
   <style>
-    html,body{height:100%;margin:0;}
-    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;background:#fff;}
-    .grid{display:flex;height:100%;}
-    .left{flex:1;display:flex;flex-direction:column;}
-    #box{flex:1;}
-    .toolbar{display:flex;gap:8px;padding:8px;}
-    .settings{width:220px;padding:8px;display:flex;flex-direction:column;gap:8px;}
-    .settings h2{margin:0 0 4px;font-size:16px;}
-    .settings-menu{display:flex;flex-direction:column;gap:8px;}
+    :root { --gap: 18px; }
+    html,body{height:100%;}
+    body{
+      margin:0;
+      font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+      color:#111827;
+      background:#f7f8fb;
+      padding:20px;
+    }
+    .wrap{max-width:1200px;margin:0 auto;}
+    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
+    .card{
+      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
+      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
+      display:flex;flex-direction:column;gap:10px;
+    }
+    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
+    #box{width:100%;aspect-ratio:1;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .btn{
+      appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;
+      padding:8px 12px;font-size:14px;cursor:pointer;
+      transition:box-shadow .2s,transform .02s;
+    }
+    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
+    .btn:active{transform:translateY(1px);}
+    .settings{display:flex;flex-direction:column;gap:10px;}
+    .settings label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
+    .settings input{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
+    .settings .row{display:flex;gap:10px;flex-wrap:wrap;}
+    .settings .row label{flex:1;}
+    .settings label.chk{flex-direction:row;align-items:center;}
+    .settings label.chk input{margin-right:6px;}
   </style>
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
 </head>
 <body>
-  <div class="grid">
-    <div class="left">
-      <div id="box" class="jxgbox" aria-label="Arealmodell rektangel"></div>
-      <div class="toolbar">
-        <button id="btnReset" type="button">Reset</button>
-        <button id="btnSvg" type="button">Last ned SVG</button>
-        <button id="btnPng" type="button">Last ned PNG</button>
-        <button id="btnSvgInteractive" type="button">Last ned interaktiv SVG</button>
-        <button id="btnHtml" type="button">Last ned interaktiv HTML</button>
+  <div class="wrap">
+    <div class="grid">
+      <div class="card">
+        <h2>Arealmodell</h2>
+        <div id="box" class="jxgbox" aria-label="Arealmodell rektangel"></div>
+        <div class="toolbar">
+          <button id="btnReset" class="btn" type="button">Reset</button>
+          <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+          <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          <button id="btnSvgInteractive" class="btn" type="button">Last ned interaktiv SVG</button>
+          <button id="btnHtml" class="btn" type="button">Last ned interaktiv HTML</button>
+        </div>
       </div>
-    </div>
-    <div class="settings">
-      <h2>Innstillinger</h2>
-      <div id="settingsMenu" class="settings-menu">
-        <label>Lengde (celler)
-          <input id="lenCells" type="number" value="1" min="1">
-        </label>
-        <label>Maks lengde
-          <input id="lenMax" type="number" value="12" min="1">
-        </label>
-        <label>Høyde (celler)
-          <input id="heiCells" type="number" value="1" min="1">
-        </label>
-        <label>Maks høyde
-          <input id="heiMax" type="number" value="12" min="1">
-        </label>
-        <label>Snap
-          <input id="snap" type="number" value="1" min="1">
-        </label>
-        <label>Areal-tekst
-          <input id="areaLabel" type="text" value="areal">
-        </label>
-        <label><input type="checkbox" id="chkGrid" checked> Vis rutenett</label>
-        <label><input type="checkbox" id="chkChallenge" checked> Oppgave-modus</label>
-        <label>Oppgave-areal
-          <input id="challengeArea" type="number" value="12" min="1">
-        </label>
-        <label><input type="checkbox" id="chkDedupe" checked> To kolonner</label>
-        <label><input type="checkbox" id="chkAutoExpand" checked> Auto maks</label>
+      <div class="card">
+        <h2>Innstillinger</h2>
+        <div id="settingsMenu" class="settings">
+          <div class="row">
+            <label>Lengde (celler)
+              <input id="lenCells" type="number" value="1" min="1">
+            </label>
+            <label>Maks lengde
+              <input id="lenMax" type="number" value="12" min="1">
+            </label>
+          </div>
+          <div class="row">
+            <label>Høyde (celler)
+              <input id="heiCells" type="number" value="1" min="1">
+            </label>
+            <label>Maks høyde
+              <input id="heiMax" type="number" value="12" min="1">
+            </label>
+          </div>
+          <label>Snap
+            <input id="snap" type="number" value="1" min="1">
+          </label>
+          <label>Areal-tekst
+            <input id="areaLabel" type="text" value="areal">
+          </label>
+          <label class="chk"><input type="checkbox" id="chkGrid" checked> Vis rutenett</label>
+          <label class="chk"><input type="checkbox" id="chkChallenge" checked> Oppgave-modus</label>
+          <label>Oppgave-areal
+            <input id="challengeArea" type="number" value="12" min="1">
+          </label>
+          <label class="chk"><input type="checkbox" id="chkDedupe" checked> To kolonner</label>
+          <label class="chk"><input type="checkbox" id="chkAutoExpand" checked> Auto maks</label>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- Rebuilt Arealmodell A page with grid/card layout and modern-normalize to match other visualizations
- Grouped and styled settings inputs with rows and inline checkboxes for consistency

## Testing
- `npm test` *(fails: Error: no test specified)*


------
https://chatgpt.com/codex/tasks/task_e_68c1203a99c08324954bedb6b1dbf6ec