### PR TITLE
Adjust settings layout with shorter inputs

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -29,10 +29,10 @@
     .status--err{ color:#b91c1c; background:#fef2f2; border-color:#fecaca; }
     .status--info{ color:#1f2937; background:#f3f4f6; border-color:#e5e7eb; }
     .settings{ display:flex; flex-direction:column; gap:8px; }
-    .settings label{ display:flex; flex-direction:column; font-size:13px; color:#4b5563; }
-    .settings input[type="text"], .settings input[type="number"]{ padding:8px 10px; border:1px solid #d1d5db; border-radius:10px; font-size:14px; background:#fff; width:100%; }
-    .settings-row{ display:flex; gap:8px; }
-    .settings-row label{ flex:1; }
+    .settings label{ display:flex; flex-direction:column; font-size:13px; color:#4b5563; max-width:160px; }
+    .settings input[type="text"], .settings input[type="number"]{ padding:8px 10px; border:1px solid #d1d5db; border-radius:10px; font-size:14px; background:#fff; width:100%; max-width:160px; }
+    .settings-row{ display:flex; gap:8px; flex-wrap:wrap; }
+    .settings-row label{ flex:0 0 160px; }
     .checkbox-label{ flex-direction:row; align-items:center; gap:6px; }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- Limit width of configuration inputs and add wrapping to keep settings panel compact.
- Prevent setting labels from stretching and allow rows to wrap for better layout.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c12297f32c83248006125f4489d446