### PR TITLE
Fix grid styling conflict in diagram

### DIFF
--- a/diagram.css
+++ b/diagram.css
@@ -1,0 +1,67 @@
+:root { --gap: 18px; }
+html,body { height: 100%; }
+body {
+  margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
+  color: #111827; background: #f7f8fb; padding: 20px;
+}
+.wrap { max-width: 1200px; margin: 0 auto; }
+.grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
+.side { display:flex; flex-direction:column; gap:var(--gap); }
+@media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
+.card {
+  background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 14px; display: flex;
+  flex-direction: column; gap: 10px;
+}
+.card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
+.figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
+.figure svg { width: 100%; height: auto; display: block; background: #fff; }
+.toolbar { display: flex; gap: 10px; justify-content: flex-end; }
+.btn {
+  appearance: none; border: 1px solid #d1d5db; background: #fff; border-radius: 10px;
+  padding: 8px 12px; font-size: 14px; cursor: pointer;
+  transition: box-shadow .2s, transform .02s;
+}
+.btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
+.btn:active { transform: translateY(1px); }
+.status {
+  position: absolute;
+  width: 1px; height: 1px; margin: -1px;
+  padding: 0; overflow: hidden; clip: rect(0,0,0,0);
+  white-space: nowrap; border: 0;
+}
+.settings { display: flex; flex-direction: column; gap: 8px; }
+.settings label { display: flex; flex-direction: column; font-size: 13px; color: #4b5563; }
+.settings input { padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 10px; font-size: 14px; background: #fff; width: 100%; }
+.settings-row { display: flex; gap: 8px; }
+.settings-row label { flex: 1; }
+#chartTitle { text-align: center; font-size: 20px; margin: 0 0 6px; }
+
+/* Akser og rutenett */
+.axis{stroke:#222;stroke-width:3;fill:none}
+.gridline{stroke:#999;stroke-width:1;opacity:.6}
+.yTickText{fill:#333;font-size:14px;text-anchor:end}
+.xLabel{fill:#333;font-size:18px;text-anchor:middle}
+.yLabel{fill:#333;font-size:18px}
+
+/* Søyler + vurderingsrammer */
+.bar{fill:#800080;stroke:#000;stroke-width:4;opacity:1;fill-opacity:1}
+.bar.badge-ok{stroke:#2e7d32;stroke-width:4}
+.bar.badge-no{stroke:#c62828;stroke-width:4}
+
+/* Håndtak */
+.handleShadow{fill:#000;opacity:.14}
+.handle{fill:#f1f1f7;stroke:#555;stroke-width:2;cursor:pointer}
+
+/* Verdi‐tekst over søyle (ikke-interaktiv) */
+.value{fill:#111;font-size:16px;text-anchor:middle;paint-order:stroke fill;stroke:#fff;stroke-width:6;pointer-events:none}
+
+/* Låsing */
+.bar.locked{cursor:not-allowed}
+.handle.locked{fill:#e5e7eb;cursor:not-allowed}
+
+/* Fokus + tastatur (A11y-overlay) */
+.a11y{cursor:ns-resize;fill:transparent;stroke:none}
+.a11y:focus{outline:none;stroke:#1e88e5;stroke-width:3}
+
+.xAxisLabel{fill:#333;font-size:18px;text-anchor:middle}

--- a/diagram.html
+++ b/diagram.html
@@ -5,75 +5,8 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Interaktivt stolpediagram (UU)</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
-  <style>
-    :root { --gap: 18px; }
-    html,body { height: 100%; }
-    body {
-      margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
-      color: #111827; background: #f7f8fb; padding: 20px;
-    }
-    .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
-    .side { display:flex; flex-direction:column; gap:var(--gap); }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
-    .card {
-      background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
-      box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 14px; display: flex;
-      flex-direction: column; gap: 10px;
-    }
-    .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
-    .figure { border-radius: 10px; background: #fafbfc; overflow: hidden; border: 1px solid #eef0f3; }
-    .figure svg { width: 100%; height: auto; display: block; background: #fff; }
-    .toolbar { display: flex; gap: 10px; justify-content: flex-end; }
-    .btn {
-      appearance: none; border: 1px solid #d1d5db; background: #fff; border-radius: 10px;
-      padding: 8px 12px; font-size: 14px; cursor: pointer;
-      transition: box-shadow .2s, transform .02s;
-    }
-    .btn:hover { box-shadow: 0 2px 8px rgba(0,0,0,.06); }
-    .btn:active { transform: translateY(1px); }
-    .status {
-      position: absolute;
-      width: 1px; height: 1px; margin: -1px;
-      padding: 0; overflow: hidden; clip: rect(0,0,0,0);
-      white-space: nowrap; border: 0;
-    }
-    .settings { display: flex; flex-direction: column; gap: 8px; }
-    .settings label { display: flex; flex-direction: column; font-size: 13px; color: #4b5563; }
-    .settings input { padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 10px; font-size: 14px; background: #fff; width: 100%; }
-    .settings-row { display: flex; gap: 8px; }
-    .settings-row label { flex: 1; }
-    #chartTitle { text-align: center; font-size: 20px; margin: 0 0 6px; }
+    <link rel="stylesheet" href="diagram.css" />
 
-    /* Akser og rutenett */
-    .axis{stroke:#222;stroke-width:3;fill:none}
-    .grid{stroke:#999;stroke-width:1;opacity:.6}
-    .yTickText{fill:#333;font-size:14px;text-anchor:end}
-    .xLabel{fill:#333;font-size:18px;text-anchor:middle}
-    .yLabel{fill:#333;font-size:18px}
-
-    /* Søyler + vurderingsrammer */
-    .bar{fill:#800080;stroke:#000;stroke-width:4;opacity:1;fill-opacity:1}
-    .bar.badge-ok{stroke:#2e7d32;stroke-width:4}
-    .bar.badge-no{stroke:#c62828;stroke-width:4}
-
-    /* Håndtak */
-    .handleShadow{fill:#000;opacity:.14}
-    .handle{fill:#f1f1f7;stroke:#555;stroke-width:2;cursor:pointer}
-
-    /* Verdi‐tekst over søyle (ikke-interaktiv) */
-    .value{fill:#111;font-size:16px;text-anchor:middle;paint-order:stroke fill;stroke:#fff;stroke-width:6;pointer-events:none}
-
-    /* Låsing */
-    .bar.locked{cursor:not-allowed}
-    .handle.locked{fill:#e5e7eb;cursor:not-allowed}
-
-    /* Fokus + tastatur (A11y-overlay) */
-    .a11y{cursor:ns-resize;fill:transparent;stroke:none}
-    .a11y:focus{outline:none;stroke:#1e88e5;stroke-width:3}
-
-    .xAxisLabel{fill:#333;font-size:18px;text-anchor:middle}
-  </style>
 </head>
 <body>
   <div class="wrap">

--- a/diagram.js
+++ b/diagram.js
@@ -79,7 +79,7 @@ function drawAxesAndGrid(){
   const step = chooseStep(yMax);
   for(let y=0; y<=yMax + 1e-9; y+=step){
     const yy = yPos(y);
-    addTo(gGrid,'line',{x1:M.l, y1:yy, x2:W-M.r, y2:yy, class:'grid'});
+    addTo(gGrid,'line',{x1:M.l, y1:yy, x2:W-M.r, y2:yy, class:'gridline'});
     addTo(gGrid,'text',{x:M.l-6,y:yy+4,class:'yTickText'}).textContent = y;
   }
 


### PR DESCRIPTION
## Summary
- Extract inline styles into a new diagram.css
- Rename SVG grid line class to avoid conflict with page layout styles

## Testing
- `npm test` (fails: Error: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68c14a1cc7a483248fadb8fbbb27a98d