### PR TITLE
Fix triangle clipping in fraction visualizer

### DIFF
--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -25,7 +25,11 @@
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
     .figure{border-radius:10px;background:#fff;overflow:visible;border:none;}
-    .figure #box{width:100%;height:420px;}
+    .figure #box{
+      width:clamp(240px,60vw,420px);
+      aspect-ratio:1;
+      margin:0 auto;
+    }
     .settings{display:flex;flex-direction:column;gap:8px;}
     .settings label{display:flex;flex-direction:column;font-size:13px;color:#4b5563;}
     .settings label.row{flex-direction:row;align-items:center;gap:8px;}


### PR DESCRIPTION
## Summary
- ensure the visualization container remains square so triangle figures render correctly

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c14e1c3bfc8324b8f56727c63f36cb