### PR TITLE
Improve Arealmodell settings layout

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -38,8 +38,9 @@
     .settings{display:flex;flex-direction:column;gap:10px;}
     .settings label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
     .settings input{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
-    .settings .row{display:flex;gap:10px;flex-wrap:wrap;}
-    .settings .row label{flex:1;}
+    .settings .row{display:flex;gap:10px;flex-wrap:wrap;align-items:flex-end;}
+    .settings .row label{flex:0;}
+    .settings .row label input[type="number"]{width:80px;}
     .settings label.chk{flex-direction:row;align-items:center;}
     .settings label.chk input{margin-right:6px;}
   </style>
@@ -91,12 +92,16 @@
             <input id="areaLabel" type="text" value="areal">
           </label>
           <label class="chk"><input type="checkbox" id="chkGrid" checked> Vis rutenett</label>
-          <label class="chk"><input type="checkbox" id="chkChallenge" checked> Oppgave-modus</label>
-          <label>Oppgave-areal
-            <input id="challengeArea" type="number" value="12" min="1">
-          </label>
-          <label class="chk"><input type="checkbox" id="chkDedupe" checked> To kolonner</label>
-          <label class="chk"><input type="checkbox" id="chkAutoExpand" checked> Auto maks</label>
+          <div class="row">
+            <label class="chk"><input type="checkbox" id="chkChallenge" checked> Oppgave-modus</label>
+            <label>Oppgave-areal
+              <input id="challengeArea" type="number" value="12" min="1">
+            </label>
+          </div>
+          <div class="row">
+            <label class="chk"><input type="checkbox" id="chkDedupe" checked> To kolonner</label>
+            <label class="chk"><input type="checkbox" id="chkAutoExpand" checked> Auto maks</label>
+          </div>
         </div>
       </div>
     </div>

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -93,8 +93,10 @@
               </label>
               <label class="chk"><input id="showHeightHandle" type="checkbox" checked> Vis håndtak</label>
             </div>
-            <label><input id="grid" type="checkbox"> Vis rutenett</label>
-            <label><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
+            <div class="row">
+              <label class="chk"><input id="grid" type="checkbox"> Vis rutenett</label>
+              <label class="chk"><input id="splitLines" type="checkbox" checked> Delingslinjer</label>
+            </div>
             <button id="btnReset" class="btn" type="button">Reset</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Arrange length and max length inputs side-by-side in Arealmodell A with fixed numeric widths.
- Group challenge-related checkboxes and area input into rows for a more compact settings menu.
- Align grid and split-line toggles in Arealmodell B on a single row for consistent layout.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c14f1b4764832493857382d0a762a4