### PR TITLE
fix: enable fraction figure clicking

### DIFF
--- a/brøkvisualiseringer.js
+++ b/brøkvisualiseringer.js
@@ -82,7 +82,8 @@
     }
     board.create('circle', [center, r], {
       strokeColor:'#333', strokeWidth:6, fillColor:'none', highlight:false,
-      fixed:true, hasInnerPoints:false
+      fixed:true, hasInnerPoints:false,
+      cssStyle:'pointer-events:none;'
     });
   }
 
@@ -143,7 +144,8 @@
       fillColor:'none',
       highlight:false,
       fixed:true,
-      hasInnerPoints:false
+      hasInnerPoints:false,
+      cssStyle:'pointer-events:none;'
     });
   }
 
@@ -217,7 +219,8 @@
       fillColor:'none',
       highlight:false,
       fixed:true,
-      hasInnerPoints:false
+      hasInnerPoints:false,
+      cssStyle:'pointer-events:none;'
     });
   }
 


### PR DESCRIPTION
## Summary
- allow clicking fraction visuals by disabling pointer events on outline shapes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c15fa083ec8324a978ff358d0c5df3