### PR TITLE
Add stepper controls to fraction visualizations

### DIFF
--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -30,6 +30,17 @@
       aspect-ratio:1;
       margin:0 auto;
     }
+    .stepper{
+      display:flex;align-items:center;gap:12px;
+      padding:6px 10px;border:1px solid #cfcfcf;border-radius:12px;
+      box-shadow:0 2px 10px rgba(0,0,0,.06);background:#fff;
+      margin:0 auto;
+    }
+    .stepper button{
+      width:40px;height:36px;border:1px solid #cfcfcf;border-radius:8px;
+      background:#fff;font-size:20px;cursor:pointer;
+    }
+    .stepper span{min-width:32px;text-align:center;font-variant-numeric:tabular-nums;font-size:16px;}
     .settings{display:flex;flex-direction:column;gap:8px;}
     .settings label{display:flex;flex-direction:column;font-size:13px;color:#4b5563;}
     .settings label.row{flex-direction:row;align-items:center;gap:8px;}
@@ -43,6 +54,11 @@
         <h2>Figur</h2>
         <div class="figure">
           <div id="box"></div>
+        </div>
+        <div class="stepper" aria-label="Antall deler">
+          <button id="partsMinus" type="button" aria-label="Færre deler">−</button>
+          <span id="partsVal">4</span>
+          <button id="partsPlus" type="button" aria-label="Flere deler">+</button>
         </div>
       </div>
       <div class="card">

--- a/brøkvisualiseringer.js
+++ b/brøkvisualiseringer.js
@@ -4,6 +4,9 @@
   const divSel   = document.getElementById('division');
   const filledInp= document.getElementById('filled');
   const wrongInp = document.getElementById('allowWrong');
+  const minusBtn = document.getElementById('partsMinus');
+  const plusBtn  = document.getElementById('partsPlus');
+  const partsVal = document.getElementById('partsVal');
   let board;
   let filled = new Set();
 
@@ -48,6 +51,8 @@
     const division = divSel.value;
     const allowWrong = wrongInp?.checked;
     if(shape==='rectangle' && division==='diagonal') n = 4;
+    partsInp.value = String(n);
+    if(partsVal) partsVal.textContent = n;
     if(shape==='circle') drawCircle(n);
     else if(shape==='rectangle') drawRect(n, division);
     else drawTriangle(n, division, allowWrong);
@@ -250,6 +255,18 @@
   divSel.addEventListener('change', draw);
   filledInp.addEventListener('input', draw);
   wrongInp.addEventListener('change', draw);
+  minusBtn?.addEventListener('click', () => {
+    let n = parseInt(partsInp.value, 10);
+    n = isNaN(n) ? 1 : Math.max(1, n - 1);
+    partsInp.value = String(n);
+    partsInp.dispatchEvent(new Event('input'));
+  });
+  plusBtn?.addEventListener('click', () => {
+    let n = parseInt(partsInp.value, 10);
+    n = isNaN(n) ? 1 : n + 1;
+    partsInp.value = String(n);
+    partsInp.dispatchEvent(new Event('input'));
+  });
 
   draw();
 })();


### PR DESCRIPTION
## Summary
- add plus/minus stepper below fraction visualization
- wire buttons to update part count and redraw figure

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c17fc8b7a88324855a6b865da4048c