### PR TITLE
Fix Arealmodell layout shifting when answer list grows

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -26,7 +26,9 @@
       display:flex;flex-direction:column;gap:10px;
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
-    #box{width:clamp(240px,60vw,420px);aspect-ratio:1;margin:0 auto;}
+    #box{width:clamp(280px,60vw,460px);aspect-ratio:1;margin:0 auto;position:relative;}
+    .pairs-list{position:absolute;top:10px;right:10px;display:flex;gap:1.2em;text-align:right;pointer-events:none;font-size:16px;line-height:1.2;}
+    .pairs-list .col{display:flex;flex-direction:column;gap:4px;}
     .toolbar{display:flex;gap:10px;justify-content:flex-end;}
     .btn{
       appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;


### PR DESCRIPTION
## Summary
- keep area model size stable by rendering factor pairs in an overlay
- enlarge frame and add top margin to accommodate overlay
- adjust bounding box handling to maintain padding

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c18531e96c8324a379899e1aea2b45