### PR TITLE
Add download export options to fraction visualizer

### DIFF
--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -41,6 +41,10 @@
       background:#fff;font-size:20px;cursor:pointer;
     }
     .stepper span{min-width:32px;text-align:center;font-variant-numeric:tabular-nums;font-size:16px;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
+    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
+    .btn:active{transform:translateY(1px)}
     .settings{display:flex;flex-direction:column;gap:8px;}
     .settings label{display:flex;flex-direction:column;font-size:13px;color:#4b5563;}
     .settings label.row{flex-direction:row;align-items:center;gap:8px;}
@@ -60,6 +64,10 @@
           <button id="partsMinus" type="button" aria-label="Færre deler">−</button>
           <span id="partsVal">4</span>
           <button id="partsPlus" type="button" aria-label="Flere deler">+</button>
+        </div>
+        <div class="toolbar">
+          <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+          <button id="btnPng" class="btn" type="button">Last ned PNG</button>
         </div>
       </div>
       <div class="card">

--- a/brøkvisualiseringer.js
+++ b/brøkvisualiseringer.js
@@ -7,6 +7,8 @@
   const minusBtn = document.getElementById('partsMinus');
   const plusBtn  = document.getElementById('partsPlus');
   const partsVal = document.getElementById('partsVal');
+  const btnSvg  = document.getElementById('btnSvg');
+  const btnPng  = document.getElementById('btnPng');
   let board;
   let filled = new Set();
 
@@ -334,6 +336,57 @@
     }
   }
 
+  function svgToString(svgEl){
+    const clone = svgEl.cloneNode(true);
+    const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
+    const style = document.createElement('style');
+    style.textContent = css;
+    clone.insertBefore(style, clone.firstChild);
+    clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
+    clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
+  }
+
+  function downloadSVG(svgEl, filename){
+    const data = svgToString(svgEl);
+    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename.endsWith('.svg') ? filename : filename + '.svg';
+    document.body.appendChild(a); a.click(); a.remove();
+    setTimeout(()=>URL.revokeObjectURL(url),1000);
+  }
+
+  function downloadPNG(svgEl, filename, scale=2, bg='#fff'){
+    const vb = svgEl.viewBox?.baseVal;
+    const w = vb?.width || svgEl.clientWidth || 420;
+    const h = vb?.height|| svgEl.clientHeight || 420;
+    const data = svgToString(svgEl);
+    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const url  = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = ()=>{
+      const canvas = document.createElement('canvas');
+      canvas.width  = Math.round(w * scale);
+      canvas.height = Math.round(h * scale);
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = bg;
+      ctx.fillRect(0,0,canvas.width,canvas.height);
+      ctx.drawImage(img,0,0,canvas.width,canvas.height);
+      URL.revokeObjectURL(url);
+      canvas.toBlob(blob=>{
+        const urlPng = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = urlPng;
+        a.download = filename.endsWith('.png') ? filename : filename + '.png';
+        document.body.appendChild(a); a.click(); a.remove();
+        setTimeout(()=>URL.revokeObjectURL(urlPng),1000);
+      },'image/png');
+    };
+    img.src = url;
+  }
+
   shapeSel.addEventListener('change', draw);
   partsInp.addEventListener('input', draw);
   divSel.addEventListener('change', draw);
@@ -350,6 +403,15 @@
     n = isNaN(n) ? 1 : n + 1;
     partsInp.value = String(n);
     partsInp.dispatchEvent(new Event('input'));
+  });
+
+  btnSvg?.addEventListener('click', () => {
+    const svg = board?.renderer?.svgRoot;
+    if(svg) downloadSVG(svg, 'brok.svg');
+  });
+  btnPng?.addEventListener('click', () => {
+    const svg = board?.renderer?.svgRoot;
+    if(svg) downloadPNG(svg, 'brok.png', 2);
   });
 
   draw();


### PR DESCRIPTION
## Summary
- Add SVG and PNG download buttons to fraction visualiser UI
- Implement client-side SVG/PNG export utilities and handlers

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c18b95a71c832495b04b97679a3f6f