### PR TITLE
Improve thinkBlocks touch dragging

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -38,7 +38,7 @@
     .checkbox-row { display:flex; align-items:center; gap:6px; }
 
     /* SVG */
-    #thinkBlocks{width:100%;height:auto;background:#fff}
+    #thinkBlocks{width:100%;height:auto;background:#fff;touch-action:none}
     .tb-rect{fill:#e8eedf}
     .tb-rect-empty{fill:#ffffff}
     .tb-frame{fill:none;stroke:#333;stroke-width:6}

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -104,8 +104,17 @@ overlay?.addEventListener('keydown', e=>{
   }
 });
 function onDragStart(e){
+  e.preventDefault();
   handle.setPointerCapture(e.pointerId);
+
+  const html = document.documentElement;
+  const prevHtmlOverscroll = html.style.overscrollBehavior;
+  const prevBodyOverscroll = document.body.style.overscrollBehavior;
+  html.style.overscrollBehavior = 'contain';
+  document.body.style.overscrollBehavior = 'contain';
+
   const move = ev=>{
+    ev.preventDefault();
     const p = clientToSvg(ev.clientX, ev.clientY);    // skjerm → viewBox
     const x = clamp(p.x, L, R);
     const cellW = (R-L)/n;
@@ -116,9 +125,11 @@ function onDragStart(e){
     handle.releasePointerCapture(e.pointerId);
     window.removeEventListener('pointermove', move);
     window.removeEventListener('pointerup', up);
+    html.style.overscrollBehavior = prevHtmlOverscroll;
+    document.body.style.overscrollBehavior = prevBodyOverscroll;
   };
-  window.addEventListener('pointermove', move);
-  window.addEventListener('pointerup', up);
+  window.addEventListener('pointermove', move, { passive: false });
+  window.addEventListener('pointerup', up, { passive: false });
 }
 
 // ---------- Utils ----------


### PR DESCRIPTION
## Summary
- disable default touch actions on thinkBlocks SVG
- prevent page scrolling during dragging and register non-passive pointer events

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1929051e8832490beb6e6b8a7699d