### PR TITLE
Add multi-series chart types

### DIFF
--- a/diagram.css
+++ b/diagram.css
@@ -32,7 +32,7 @@ body {
 }
 .settings { display: flex; flex-direction: column; gap: 8px; }
 .settings label { display: flex; flex-direction: column; font-size: 13px; color: #4b5563; }
-.settings input { padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 10px; font-size: 14px; background: #fff; width: 100%; }
+.settings input, .settings select { padding: 8px 10px; border: 1px solid #d1d5db; border-radius: 10px; font-size: 14px; background: #fff; width: 100%; }
 .settings-row { display: flex; gap: 8px; }
 .settings-row label { flex: 1; }
 #chartTitle { text-align: center; font-size: 20px; margin: 0 0 6px; }
@@ -45,9 +45,23 @@ body {
 .yLabel{fill:#333;font-size:18px}
 
 /* Søyler + vurderingsrammer */
-.bar{fill:#800080;stroke:#000;stroke-width:4;opacity:1;fill-opacity:1}
+.bar{stroke:#000;stroke-width:4;opacity:1;fill-opacity:1}
+.bar.series0{fill:#574595}
+.bar.series1{fill:#d081a1}
 .bar.badge-ok{stroke:#2e7d32;stroke-width:4}
 .bar.badge-no{stroke:#c62828;stroke-width:4}
+
+/* Linjediagram */
+.line{fill:none;stroke-width:4}
+.line.series0{stroke:#574595}
+.line.series1{stroke:#d081a1}
+.line-dot.series0{fill:#574595}
+.line-dot.series1{fill:#d081a1}
+
+/* Legend */
+.legendbox.series0{fill:#574595}
+.legendbox.series1{fill:#d081a1}
+.legendtext{fill:#333;font-size:16px}
 
 /* Håndtak */
 .handleShadow{fill:#000;opacity:.14}

--- a/diagram.html
+++ b/diagram.html
@@ -36,34 +36,58 @@
         <div class="card">
           <h2>Forfatters innstillinger</h2>
           <div class="settings">
+          <label>Type
+            <select id="cfgType">
+              <option value="line">Linje</option>
+              <option value="bar">Stolpe</option>
+              <option value="stacked">Stablede stolper</option>
+              <option value="grouped">Grupperte stolper</option>
+            </select>
+          </label>
           <label>Overskrift
-            <input id="cfgTitle" type="text" value="Favorittidretter i 5B">
+            <input id="cfgTitle" type="text" value="Skjermtid per dag">
           </label>
           <div class="settings-row">
             <label>Etiketter (kommaseparert)
-              <input id="cfgLabels" type="text" value="Klatring,Fotball,Håndball,Basket,Tennis,Bowling">
+              <input id="cfgLabels" type="text" value="1,2,3,4,5,6,7">
             </label>
             <label>Fjern håndtak (0/1, kommaseparert)
               <input id="cfgLocked" type="text" value="">
             </label>
           </div>
           <div class="settings-row">
-            <label>Startverdier
-              <input id="cfgStart" type="text" value="6,7,3,5,8,2">
+            <label>Serienavn 1
+              <input id="cfgSeries1" type="text" value="Gutter">
             </label>
-            <label>Fasitverdier
-              <input id="cfgAnswer" type="text" value="6,7,3,5,8,2">
+            <label>Serienavn 2
+              <input id="cfgSeries2" type="text" value="Jenter">
+            </label>
+          </div>
+          <div class="settings-row">
+            <label>Startverdier 1
+              <input id="cfgStart" type="text" value="1,6,1,1,2,1,0">
+            </label>
+            <label>Startverdier 2
+              <input id="cfgStart2" type="text" value="1,3,2,0,2,0,0">
+            </label>
+          </div>
+          <div class="settings-row">
+            <label>Fasitverdier 1
+              <input id="cfgAnswer" type="text" value="1,6,1,1,2,1,0">
+            </label>
+            <label>Fasitverdier 2
+              <input id="cfgAnswer2" type="text" value="1,3,2,0,2,0,0">
             </label>
           </div>
           <div class="settings-row">
             <label>Maks y (valgfritt)
-              <input id="cfgYMax" type="text" value="8">
+              <input id="cfgYMax" type="text" value="9">
             </label>
             <label>Navn på x-akse
-              <input id="cfgAxisXLabel" type="text" value="Idrett">
+              <input id="cfgAxisXLabel" type="text" value="Timer per dag">
             </label>
             <label>Navn på y-akse
-              <input id="cfgAxisYLabel" type="text" value="Antall elever">
+              <input id="cfgAxisYLabel" type="text" value="Antall personer">
             </label>
           </div>
           <label>Steg (snap)


### PR DESCRIPTION
## Summary
- Support up to two data series with configurable chart type
- Render line, stacked bar, or grouped bar charts with legends and colors
- Add author settings for series names, values, and chart type selection

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c19400c038832490ece43c366f6c71