### PR TITLE
Add dual figure support to fraction visualizations

### DIFF
--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -18,6 +18,17 @@
     .wrap{max-width:1200px;margin:0 auto;}
     .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
     @media(max-width:980px){.grid{grid-template-columns:1fr;}}
+    .grid2{
+      display:grid;
+      grid-template-columns:repeat(2,minmax(0,1fr));
+      gap:24px;
+      align-items:start;
+    }
+    .figurePanel{display:grid;place-items:center;gap:10px;}
+    @media(max-width:420px){
+      .grid2{grid-template-columns:1fr;gap:16px;}
+      .figure .box{width:clamp(240px,92vw,420px);}
+    }
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;
       box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;display:flex;
@@ -25,8 +36,8 @@
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
     .figure{border-radius:10px;background:#fff;overflow:visible;border:none;}
-    .figure #box{
-      width:clamp(240px,60vw,420px);
+    .figure .box{
+      width:clamp(100px,40vw,420px);
       aspect-ratio:1;
       margin:0 auto;
     }
@@ -45,56 +56,102 @@
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
     .btn:active{transform:translateY(1px)}
-    .settings{display:flex;flex-direction:column;gap:8px;}
+    .settings{display:flex;gap:var(--gap);}
+    .settings fieldset{flex:1;display:flex;flex-direction:column;gap:8px;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;}
+    legend{font-weight:600;font-size:13px;color:#374151;padding:0 4px;}
     .settings label{display:flex;flex-direction:column;font-size:13px;color:#4b5563;}
-    .settings label.row{flex-direction:row;align-items:center;gap:8px;}
     .settings input,.settings select{padding:8px 10px;border:1px solid #d1d5db;border-radius:10px;font-size:14px;background:#fff;}
-    #box svg *:focus{outline:none;}
+    .checkbox-row{display:flex;align-items:center;gap:6px;}
+    .box svg *:focus{outline:none;}
   </style>
 </head>
 <body>
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <h2>Figur</h2>
-        <div class="figure">
-          <div id="box"></div>
-        </div>
-        <div class="stepper" aria-label="Antall deler">
-          <button id="partsMinus" type="button" aria-label="Færre deler">−</button>
-          <span id="partsVal">4</span>
-          <button id="partsPlus" type="button" aria-label="Flere deler">+</button>
-        </div>
-        <div class="toolbar">
-          <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
-          <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+        <h2>Figurer</h2>
+        <div class="grid2">
+          <div id="panel1" class="figurePanel">
+            <div class="figure"><div id="box1" class="box"></div></div>
+            <div class="stepper" aria-label="Antall deler">
+              <button id="partsMinus1" type="button" aria-label="Færre deler">−</button>
+              <span id="partsVal1">4</span>
+              <button id="partsPlus1" type="button" aria-label="Flere deler">+</button>
+            </div>
+            <div class="toolbar">
+              <button id="btnSvg1" class="btn" type="button">Last ned SVG</button>
+              <button id="btnPng1" class="btn" type="button">Last ned PNG</button>
+            </div>
+          </div>
+          <div id="panel2" class="figurePanel">
+            <div class="figure"><div id="box2" class="box"></div></div>
+            <div class="stepper" aria-label="Antall deler">
+              <button id="partsMinus2" type="button" aria-label="Færre deler">−</button>
+              <span id="partsVal2">4</span>
+              <button id="partsPlus2" type="button" aria-label="Flere deler">+</button>
+            </div>
+            <div class="toolbar">
+              <button id="btnSvg2" class="btn" type="button">Last ned SVG</button>
+              <button id="btnPng2" class="btn" type="button">Last ned PNG</button>
+            </div>
+          </div>
         </div>
       </div>
       <div class="card">
         <h2>Forfatters innstillinger</h2>
         <div class="settings">
-          <label>Form
-            <select id="shape">
-              <option value="circle">sirkel</option>
-              <option value="rectangle">rektangel</option>
-              <option value="triangle">trekant</option>
-            </select>
-          </label>
-          <label>Antall deler
-            <input id="parts" type="number" min="1" value="4" />
-          </label>
-          <label>Delt
-            <select id="division">
-              <option value="horizontal">horisontalt</option>
-              <option value="vertical">vertikalt</option>
-              <option value="diagonal">diagonalt</option>
-              <option value="grid">horisontalt og vertikalt</option>
-            </select>
-          </label>
-          <label>Fylte deler (kommaseparert, klikk på figuren for å fargelegge)
-            <input id="filled" type="text" value="0" />
-          </label>
-          <label class="row"><input id="allowWrong" type="checkbox" /> Tillat gale illustrasjoner</label>
+          <fieldset>
+            <legend>Figur 1</legend>
+            <div class="checkbox-row"><input id="show1" type="checkbox" checked><label for="show1">Vis</label></div>
+            <label>Form
+              <select id="shape1">
+                <option value="circle">sirkel</option>
+                <option value="rectangle">rektangel</option>
+                <option value="triangle">trekant</option>
+              </select>
+            </label>
+            <label>Antall deler
+              <input id="parts1" type="number" min="1" value="4" />
+            </label>
+            <label>Delt
+              <select id="division1">
+                <option value="horizontal">horisontalt</option>
+                <option value="vertical">vertikalt</option>
+                <option value="diagonal">diagonalt</option>
+                <option value="grid">horisontalt og vertikalt</option>
+              </select>
+            </label>
+            <label>Fylte deler (kommaseparert, klikk på figuren for å fargelegge)
+              <input id="filled1" type="text" value="0" />
+            </label>
+            <div class="checkbox-row"><input id="allowWrong1" type="checkbox" /><label for="allowWrong1">Tillat gale illustrasjoner</label></div>
+          </fieldset>
+          <fieldset>
+            <legend>Figur 2</legend>
+            <div class="checkbox-row"><input id="show2" type="checkbox" checked><label for="show2">Vis</label></div>
+            <label>Form
+              <select id="shape2">
+                <option value="circle">sirkel</option>
+                <option value="rectangle">rektangel</option>
+                <option value="triangle">trekant</option>
+              </select>
+            </label>
+            <label>Antall deler
+              <input id="parts2" type="number" min="1" value="4" />
+            </label>
+            <label>Delt
+              <select id="division2">
+                <option value="horizontal">horisontalt</option>
+                <option value="vertical">vertikalt</option>
+                <option value="diagonal">diagonalt</option>
+                <option value="grid">horisontalt og vertikalt</option>
+              </select>
+            </label>
+            <label>Fylte deler (kommaseparert, klikk på figuren for å fargelegge)
+              <input id="filled2" type="text" value="0" />
+            </label>
+            <div class="checkbox-row"><input id="allowWrong2" type="checkbox" /><label for="allowWrong2">Tillat gale illustrasjoner</label></div>
+          </fieldset>
         </div>
       </div>
     </div>

--- a/brøkvisualiseringer.js
+++ b/brøkvisualiseringer.js
@@ -1,341 +1,4 @@
 (function(){
-  const shapeSel = document.getElementById('shape');
-  const partsInp = document.getElementById('parts');
-  const divSel   = document.getElementById('division');
-  const filledInp= document.getElementById('filled');
-  const wrongInp = document.getElementById('allowWrong');
-  const minusBtn = document.getElementById('partsMinus');
-  const plusBtn  = document.getElementById('partsPlus');
-  const partsVal = document.getElementById('partsVal');
-  const btnSvg  = document.getElementById('btnSvg');
-  const btnPng  = document.getElementById('btnPng');
-  let board;
-  let filled = new Set();
-
-  function initBoard(){
-    if(board) JXG.JSXGraph.freeBoard(board);
-    board = JXG.JSXGraph.initBoard('box', {
-      boundingbox:[0,1,1,0], axis:false, showCopyright:false,
-      showNavigation:false, keepaspectratio:true
-    });
-  }
-
-  function parseFilled(){
-    filled = new Set(
-      filledInp.value
-        .split(',')
-        .map(s=>parseInt(s.trim(),10))
-        .filter(n=>!isNaN(n))
-    );
-  }
-
-  function updateFilledInput(){
-    filledInp.value = Array.from(filled).sort((a,b)=>a-b).join(',');
-  }
-
-  function togglePart(i, element){
-    if(filled.has(i)){
-      filled.delete(i);
-      element.setAttribute({fillColor:'#fff', fillOpacity:1});
-    }else{
-      filled.add(i);
-      element.setAttribute({fillColor:'#5B2AA5', fillOpacity:1});
-    }
-    updateFilledInput();
-    board.update();
-  }
-
-  function gridDims(n){
-    let cols = Math.floor(Math.sqrt(n));
-    while(n % cols !== 0) cols--;
-    const rows = n / cols;
-    return {rows, cols};
-  }
-
-  function draw(){
-    initBoard();
-    let n = Math.max(1, parseInt(partsInp.value,10));
-    parseFilled();
-    const shape = shapeSel.value;
-    let division = divSel.value;
-    const allowWrong = wrongInp?.checked;
-    if(shape==='rectangle' && division==='diagonal') n = 4;
-    const gridOpt = divSel.querySelector('option[value="grid"]');
-    const vertOpt = divSel.querySelector('option[value="vertical"]');
-    if(gridOpt){
-      gridOpt.hidden = n % 2 === 1 || (shape==='circle' && !allowWrong) || (shape==='triangle');
-      if(gridOpt.hidden && division==='grid') divSel.value = 'horizontal';
-    }
-    if(vertOpt){
-      vertOpt.hidden = (shape==='circle' && !allowWrong);
-      if(vertOpt.hidden && division==='vertical') divSel.value = 'horizontal';
-    }
-    division = divSel.value;
-    partsInp.value = String(n);
-    if(partsVal) partsVal.textContent = n;
-    if(shape==='circle') drawCircle(n, division, allowWrong);
-    else if(shape==='rectangle') drawRect(n, division);
-    else drawTriangle(n, division, allowWrong);
-    applyClip(shape);
-  }
-
-  function drawCircle(n, division, allowWrong){
-    const r = 0.45;
-    const cx = 0.5, cy = 0.5;
-    const pointOpts = {visible:false, fixed:true, name:'', label:{visible:false}};
-    if(allowWrong && (division==='vertical' || division==='horizontal' || division==='grid')){
-      let rows=1, cols=n;
-      if(division==='horizontal'){ rows=n; cols=1; }
-      else if(division==='grid'){ const d=gridDims(n); rows=d.rows; cols=d.cols; }
-      for(let rIdx=0;rIdx<rows;rIdx++){
-        for(let cIdx=0;cIdx<cols;cIdx++){
-          const idx=rIdx*cols+cIdx;
-          const x1=cIdx/cols, x2=(cIdx+1)/cols;
-          const y1=rIdx/rows, y2=(rIdx+1)/rows;
-          const poly=board.create('polygon', [[x1,y1],[x2,y1],[x2,y2],[x1,y2]], {
-            borders:{strokeColor:'#fff', strokeWidth:6},
-            vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
-            fillColor: filled.has(idx)?'#5B2AA5':'#fff',
-            fillOpacity:1,
-            highlight:false,
-            hasInnerPoints:true,
-            fixed:true
-          });
-          poly.on('down', () => togglePart(idx, poly));
-        }
-      }
-      for(let i=1;i<cols;i++){
-        const x=i/cols;
-        board.create('segment', [[x,0],[x,1]], {strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'});
-      }
-      for(let j=1;j<rows;j++){
-        const y=j/rows;
-        board.create('segment', [[0,y],[1,y]], {strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'});
-      }
-      board.create('circle', [[cx,cy], r], {
-        strokeColor:'#333', strokeWidth:6, fillColor:'none', highlight:false,
-        fixed:true, hasInnerPoints:false,
-        cssStyle:'pointer-events:none;'
-      });
-    }else{
-      const center = board.create('point', [cx,cy], pointOpts);
-      const boundaryPts = [];
-      for(let i=0;i<n;i++){
-        const a1 = 2*Math.PI*i/n;
-        const a2 = 2*Math.PI*(i+1)/n;
-        const p1 = board.create('point', [cx + r*Math.cos(a1), cy + r*Math.sin(a1)], pointOpts);
-        const p2 = board.create('point', [cx + r*Math.cos(a2), cy + r*Math.sin(a2)], pointOpts);
-        boundaryPts.push(p1);
-        const sector = board.create('sector', [center, p1, p2], {
-          withLines:true,
-          strokeColor:'#fff',
-          strokeWidth:6,
-          fillColor: filled.has(i)?'#5B2AA5':'#fff',
-          fillOpacity:1,
-          highlight:false,
-          hasInnerPoints:true,
-          fixed:true
-        });
-        sector.on('down', () => togglePart(i, sector));
-      }
-      for(const p of boundaryPts){
-        board.create('segment', [center, p], {
-          strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
-        });
-      }
-      board.create('circle', [center, r], {
-        strokeColor:'#333', strokeWidth:6, fillColor:'none', highlight:false,
-        fixed:true, hasInnerPoints:false,
-        cssStyle:'pointer-events:none;'
-      });
-    }
-  }
-
-  function drawRect(n, division){
-    if(division==='diagonal'){
-      const c = [0.5,0.5];
-      const corners = [[0,0],[1,0],[1,1],[0,1]];
-      for(let i=0;i<4;i++){
-        const pts = [corners[i], corners[(i+1)%4], c];
-        const poly = board.create('polygon', pts, {
-          borders:{strokeColor:'#fff', strokeWidth:6},
-          vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
-          fillColor: filled.has(i)?'#5B2AA5':'#fff',
-          fillOpacity:1,
-          highlight:false,
-          hasInnerPoints:true,
-          fixed:true
-        });
-        poly.on('down', () => togglePart(i, poly));
-        board.create('segment', [c, corners[i]], {
-          strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
-        });
-      }
-    }else if(division==='grid'){
-      const {rows, cols} = gridDims(n);
-      for(let rIdx=0;rIdx<rows;rIdx++){
-        for(let cIdx=0;cIdx<cols;cIdx++){
-          const idx=rIdx*cols+cIdx;
-          const x1=cIdx/cols, x2=(cIdx+1)/cols;
-          const y1=rIdx/rows, y2=(rIdx+1)/rows;
-          const pts=[[x1,y1],[x2,y1],[x2,y2],[x1,y2]];
-          const poly=board.create('polygon', pts, {
-            borders:{strokeColor:'#fff', strokeWidth:6},
-            vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
-            fillColor: filled.has(idx)?'#5B2AA5':'#fff',
-            fillOpacity:1,
-            highlight:false,
-            hasInnerPoints:true,
-            fixed:true
-          });
-          poly.on('down', () => togglePart(idx, poly));
-        }
-      }
-      for(let i=1;i<cols;i++){
-        const x=i/cols;
-        board.create('segment', [[x,0],[x,1]], {strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'});
-      }
-      for(let j=1;j<rows;j++){
-        const y=j/rows;
-        board.create('segment', [[0,y],[1,y]], {strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'});
-      }
-    }else{
-      for(let i=0;i<n;i++){
-        let pts;
-        if(division==='vertical'){
-          const x1 = i/n, x2 = (i+1)/n;
-          pts = [[x1,0],[x2,0],[x2,1],[x1,1]];
-        }else{ // horizontal
-          const y1 = i/n, y2 = (i+1)/n;
-          pts = [[0,y1],[1,y1],[1,y2],[0,y2]];
-        }
-        const poly = board.create('polygon', pts, {
-          borders:{strokeColor:'#fff', strokeWidth:6},
-          vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
-          fillColor: filled.has(i)?'#5B2AA5':'#fff',
-          fillOpacity:1,
-          highlight:false,
-          hasInnerPoints:true,
-          fixed:true
-        });
-        poly.on('down', () => togglePart(i, poly));
-      }
-      for(let i=1;i<n;i++){
-        if(division==='vertical'){
-          const x=i/n;
-          board.create('segment', [[x,0],[x,1]], {
-            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
-          });
-        }else{
-          const y=i/n;
-          board.create('segment', [[0,y],[1,y]], {
-            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
-          });
-        }
-      }
-    }
-    board.create('polygon', [[0,0],[1,0],[1,1],[0,1]], {
-      borders:{strokeColor:'#333', strokeWidth:6},
-      vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
-      fillColor:'none',
-      highlight:false,
-      fixed:true,
-      hasInnerPoints:false,
-      cssStyle:'pointer-events:none;'
-    });
-  }
-
-  function drawTriangle(n, division, allowWrong){
-    for(let i=0;i<n;i++){
-      let pts;
-      if(division==='vertical'){
-        const x1=i/n, x2=(i+1)/n;
-        if(allowWrong){
-          pts=[[x1,0],[x2,0],[x2,1-x2],[x1,1-x1]];
-        }else{
-          pts=[[x1,0],[x2,0],[0,1]];
-        }
-      }else if(division==='horizontal'){
-        const y1=i/n, y2=(i+1)/n;
-        if(allowWrong){
-          pts=[[0,y1],[1-y1,y1],[1-y2,y2],[0,y2]];
-        }else{
-          pts=[[0,y1],[0,y2],[1,0]];
-        }
-      }else{ // diagonal
-        const t1=i/n, t2=(i+1)/n;
-        pts=[[1-t1,t1],[1-t2,t2],[0,0]];
-      }
-      const poly = board.create('polygon', pts, {
-        borders:{strokeColor:'#fff', strokeWidth:6},
-        vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
-        fillColor: filled.has(i)?'#5B2AA5':'#fff',
-        fillOpacity:1,
-        highlight:false,
-        hasInnerPoints:true,
-        fixed:true
-      });
-      poly.on('down', () => togglePart(i, poly));
-    }
-    if(division==='vertical'){
-      for(let i=1;i<n;i++){
-        const x=i/n;
-        if(allowWrong){
-          board.create('segment', [[x,0],[x,1-x]], {
-            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
-          });
-        }else{
-          board.create('segment', [[x,0],[0,1]], {
-            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
-          });
-        }
-      }
-    }else if(division==='horizontal'){
-      for(let i=1;i<n;i++){
-        const y=i/n;
-        if(allowWrong){
-          board.create('segment', [[0,y],[1-y,y]], {
-            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
-          });
-        }else{
-          board.create('segment', [[0,y],[1,0]], {
-            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
-          });
-        }
-      }
-    }else{ // diagonal
-      for(let i=1;i<n;i++){
-        const t=i/n;
-        board.create('segment', [[1-t,t],[0,0]], {
-          strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
-        });
-      }
-    }
-    board.create('polygon', [[0,0],[1,0],[0,1]], {
-      borders:{strokeColor:'#333', strokeWidth:6},
-      vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
-      fillColor:'none',
-      highlight:false,
-      fixed:true,
-      hasInnerPoints:false,
-      cssStyle:'pointer-events:none;'
-    });
-  }
-
-  function applyClip(shape){
-    const svg = board?.renderer?.svgRoot;
-    if(!svg) return;
-    if(shape==='triangle'){
-      svg.style.clipPath = 'polygon(-2% 102%, 102% 102%, -2% -2%)';
-    }else if(shape==='rectangle'){
-      svg.style.clipPath = 'polygon(-2% 102%, 102% 102%, 102% -2%, -2% -2%)';
-    }else if(shape==='circle'){
-      svg.style.clipPath = 'circle(45% at 50% 50%)';
-    }else{
-      svg.style.clipPath = '';
-    }
-  }
-
   function svgToString(svgEl){
     const clone = svgEl.cloneNode(true);
     const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
@@ -387,32 +50,380 @@
     img.src = url;
   }
 
-  shapeSel.addEventListener('change', draw);
-  partsInp.addEventListener('input', draw);
-  divSel.addEventListener('change', draw);
-  filledInp.addEventListener('input', draw);
-  wrongInp.addEventListener('change', draw);
-  minusBtn?.addEventListener('click', () => {
-    let n = parseInt(partsInp.value, 10);
-    n = isNaN(n) ? 1 : Math.max(1, n - 1);
-    partsInp.value = String(n);
-    partsInp.dispatchEvent(new Event('input'));
-  });
-  plusBtn?.addEventListener('click', () => {
-    let n = parseInt(partsInp.value, 10);
-    n = isNaN(n) ? 1 : n + 1;
-    partsInp.value = String(n);
-    partsInp.dispatchEvent(new Event('input'));
-  });
+  function setupFigure(id){
+    const shapeSel = document.getElementById(`shape${id}`);
+    const partsInp = document.getElementById(`parts${id}`);
+    const divSel   = document.getElementById(`division${id}`);
+    const filledInp= document.getElementById(`filled${id}`);
+    const wrongInp = document.getElementById(`allowWrong${id}`);
+    const minusBtn = document.getElementById(`partsMinus${id}`);
+    const plusBtn  = document.getElementById(`partsPlus${id}`);
+    const partsVal = document.getElementById(`partsVal${id}`);
+    const btnSvg   = document.getElementById(`btnSvg${id}`);
+    const btnPng   = document.getElementById(`btnPng${id}`);
+    const showInp  = document.getElementById(`show${id}`);
+    const panel    = document.getElementById(`panel${id}`);
+    let board;
+    let filled = new Set();
 
-  btnSvg?.addEventListener('click', () => {
-    const svg = board?.renderer?.svgRoot;
-    if(svg) downloadSVG(svg, 'brok.svg');
-  });
-  btnPng?.addEventListener('click', () => {
-    const svg = board?.renderer?.svgRoot;
-    if(svg) downloadPNG(svg, 'brok.png', 2);
-  });
+    function initBoard(){
+      if(board) JXG.JSXGraph.freeBoard(board);
+      board = JXG.JSXGraph.initBoard(`box${id}`, {
+        boundingbox:[0,1,1,0], axis:false, showCopyright:false,
+        showNavigation:false, keepaspectratio:true
+      });
+    }
 
-  draw();
+    function parseFilled(){
+      filled = new Set(
+        filledInp.value
+          .split(',')
+          .map(s=>parseInt(s.trim(),10))
+          .filter(n=>!isNaN(n))
+      );
+    }
+
+    function updateFilledInput(){
+      filledInp.value = Array.from(filled).sort((a,b)=>a-b).join(',');
+    }
+
+    function togglePart(i, element){
+      if(filled.has(i)){
+        filled.delete(i);
+        element.setAttribute({fillColor:'#fff', fillOpacity:1});
+      }else{
+        filled.add(i);
+        element.setAttribute({fillColor:'#5B2AA5', fillOpacity:1});
+      }
+      updateFilledInput();
+      board.update();
+    }
+
+    function gridDims(n){
+      let cols = Math.floor(Math.sqrt(n));
+      while(n % cols !== 0) cols--;
+      const rows = n / cols;
+      return {rows, cols};
+    }
+
+    function draw(){
+      initBoard();
+      let n = Math.max(1, parseInt(partsInp.value,10));
+      parseFilled();
+      const shape = shapeSel.value;
+      let division = divSel.value;
+      const allowWrong = wrongInp?.checked;
+      if(shape==='rectangle' && division==='diagonal') n = 4;
+      const gridOpt = divSel.querySelector('option[value="grid"]');
+      const vertOpt = divSel.querySelector('option[value="vertical"]');
+      if(gridOpt){
+        gridOpt.hidden = n % 2 === 1 || (shape==='circle' && !allowWrong) || (shape==='triangle');
+        if(gridOpt.hidden && division==='grid') divSel.value = 'horizontal';
+      }
+      if(vertOpt){
+        vertOpt.hidden = (shape==='circle' && !allowWrong);
+        if(vertOpt.hidden && division==='vertical') divSel.value = 'horizontal';
+      }
+      division = divSel.value;
+      partsInp.value = String(n);
+      if(partsVal) partsVal.textContent = n;
+      if(shape==='circle') drawCircle(n, division, allowWrong);
+      else if(shape==='rectangle') drawRect(n, division);
+      else drawTriangle(n, division, allowWrong);
+      applyClip(shape);
+    }
+
+    function drawCircle(n, division, allowWrong){
+      const r = 0.45;
+      const cx = 0.5, cy = 0.5;
+      const pointOpts = {visible:false, fixed:true, name:'', label:{visible:false}};
+      if(allowWrong && (division==='vertical' || division==='horizontal' || division==='grid')){
+        let rows=1, cols=n;
+        if(division==='horizontal'){ rows=n; cols=1; }
+        else if(division==='grid'){ const d=gridDims(n); rows=d.rows; cols=d.cols; }
+        for(let rIdx=0;rIdx<rows;rIdx++){
+          for(let cIdx=0;cIdx<cols;cIdx++){
+            const idx=rIdx*cols+cIdx;
+            const x1=cIdx/cols, x2=(cIdx+1)/cols;
+            const y1=rIdx/rows, y2=(rIdx+1)/rows;
+            const poly=board.create('polygon', [[x1,y1],[x2,y1],[x2,y2],[x1,y2]], {
+              borders:{strokeColor:'#fff', strokeWidth:6},
+              vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+              fillColor: filled.has(idx)?'#5B2AA5':'#fff',
+              fillOpacity:1,
+              highlight:false,
+              hasInnerPoints:true,
+              fixed:true
+            });
+            poly.on('down', () => togglePart(idx, poly));
+          }
+        }
+        for(let i=1;i<cols;i++){
+          const x=i/cols;
+          board.create('segment', [[x,0],[x,1]], {strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'});
+        }
+        for(let j=1;j<rows;j++){
+          const y=j/rows;
+          board.create('segment', [[0,y],[1,y]], {strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'});
+        }
+        board.create('circle', [[cx,cy], r], {
+          strokeColor:'#333', strokeWidth:6, fillColor:'none', highlight:false,
+          fixed:true, hasInnerPoints:false,
+          cssStyle:'pointer-events:none;'
+        });
+      }else{
+        const center = board.create('point', [cx,cy], pointOpts);
+        const boundaryPts = [];
+        for(let i=0;i<n;i++){
+          const a1 = 2*Math.PI*i/n;
+          const a2 = 2*Math.PI*(i+1)/n;
+          const p1 = board.create('point', [cx + r*Math.cos(a1), cy + r*Math.sin(a1)], pointOpts);
+          const p2 = board.create('point', [cx + r*Math.cos(a2), cy + r*Math.sin(a2)], pointOpts);
+          boundaryPts.push(p1);
+          const sector = board.create('sector', [center, p1, p2], {
+            withLines:true,
+            strokeColor:'#fff',
+            strokeWidth:6,
+            fillColor: filled.has(i)?'#5B2AA5':'#fff',
+            fillOpacity:1,
+            highlight:false,
+            hasInnerPoints:true,
+            fixed:true
+          });
+          sector.on('down', () => togglePart(i, sector));
+        }
+        for(const p of boundaryPts){
+          board.create('segment', [center, p], {
+            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+          });
+        }
+        board.create('circle', [center, r], {
+          strokeColor:'#333', strokeWidth:6, fillColor:'none', highlight:false,
+          fixed:true, hasInnerPoints:false,
+          cssStyle:'pointer-events:none;'
+        });
+      }
+    }
+
+    function drawRect(n, division){
+      if(division==='diagonal'){
+        const c = [0.5,0.5];
+        const corners = [[0,0],[1,0],[1,1],[0,1]];
+        for(let i=0;i<4;i++){
+          const pts = [corners[i], corners[(i+1)%4], c];
+          const poly = board.create('polygon', pts, {
+            borders:{strokeColor:'#fff', strokeWidth:6},
+            vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+            fillColor: filled.has(i)?'#5B2AA5':'#fff',
+            fillOpacity:1,
+            highlight:false,
+            hasInnerPoints:true,
+            fixed:true
+          });
+          poly.on('down', () => togglePart(i, poly));
+          board.create('segment', [c, corners[i]], {
+            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+          });
+        }
+      }else if(division==='grid'){
+        const {rows, cols} = gridDims(n);
+        for(let rIdx=0;rIdx<rows;rIdx++){
+          for(let cIdx=0;cIdx<cols;cIdx++){
+            const idx=rIdx*cols+cIdx;
+            const x1=cIdx/cols, x2=(cIdx+1)/cols;
+            const y1=rIdx/rows, y2=(rIdx+1)/rows;
+            const pts=[[x1,y1],[x2,y1],[x2,y2],[x1,y2]];
+            const poly=board.create('polygon', pts, {
+              borders:{strokeColor:'#fff', strokeWidth:6},
+              vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+              fillColor: filled.has(idx)?'#5B2AA5':'#fff',
+              fillOpacity:1,
+              highlight:false,
+              hasInnerPoints:true,
+              fixed:true
+            });
+            poly.on('down', () => togglePart(idx, poly));
+          }
+        }
+        for(let i=1;i<cols;i++){
+          const x=i/cols;
+          board.create('segment', [[x,0],[x,1]], {strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'});
+        }
+        for(let j=1;j<rows;j++){
+          const y=j/rows;
+          board.create('segment', [[0,y],[1,y]], {strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'});
+        }
+      }else{
+        for(let i=0;i<n;i++){
+          let pts;
+          if(division==='vertical'){
+            const x1 = i/n, x2 = (i+1)/n;
+            pts = [[x1,0],[x2,0],[x2,1],[x1,1]];
+          }else{ // horizontal
+            const y1 = i/n, y2 = (i+1)/n;
+            pts = [[0,y1],[1,y1],[1,y2],[0,y2]];
+          }
+          const poly = board.create('polygon', pts, {
+            borders:{strokeColor:'#fff', strokeWidth:6},
+            vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+            fillColor: filled.has(i)?'#5B2AA5':'#fff',
+            fillOpacity:1,
+            highlight:false,
+            hasInnerPoints:true,
+            fixed:true
+          });
+          poly.on('down', () => togglePart(i, poly));
+        }
+        for(let i=1;i<n;i++){
+          if(division==='vertical'){
+            const x=i/n;
+            board.create('segment', [[x,0],[x,1]], {
+              strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+            });
+          }else{
+            const y=i/n;
+            board.create('segment', [[0,y],[1,y]], {
+              strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+            });
+          }
+        }
+      }
+      board.create('polygon', [[0,0],[1,0],[1,1],[0,1]], {
+        borders:{strokeColor:'#333', strokeWidth:6},
+        vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+        fillColor:'none',
+        highlight:false,
+        fixed:true,
+        hasInnerPoints:false,
+        cssStyle:'pointer-events:none;'
+      });
+    }
+
+    function drawTriangle(n, division, allowWrong){
+      for(let i=0;i<n;i++){
+        let pts;
+        if(division==='vertical'){
+          const x1=i/n, x2=(i+1)/n;
+          if(allowWrong){
+            pts=[[x1,0],[x2,0],[x2,1-x2],[x1,1-x1]];
+          }else{
+            pts=[[x1,0],[x2,0],[0,1]];
+          }
+        }else if(division==='horizontal'){
+          const y1=i/n, y2=(i+1)/n;
+          if(allowWrong){
+            pts=[[0,y1],[1-y1,y1],[1-y2,y2],[0,y2]];
+          }else{
+            pts=[[0,y1],[0,y2],[1,0]];
+          }
+        }else{ // diagonal
+          const t1=i/n, t2=(i+1)/n;
+          pts=[[1-t1,t1],[1-t2,t2],[0,0]];
+        }
+        const poly = board.create('polygon', pts, {
+          borders:{strokeColor:'#fff', strokeWidth:6},
+          vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+          fillColor: filled.has(i)?'#5B2AA5':'#fff',
+          fillOpacity:1,
+          highlight:false,
+          hasInnerPoints:true,
+          fixed:true
+        });
+        poly.on('down', () => togglePart(i, poly));
+      }
+      if(division==='vertical'){
+        for(let i=1;i<n;i++){
+          const x=i/n;
+          if(allowWrong){
+            board.create('segment', [[x,0],[x,1-x]], {
+              strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+            });
+          }else{
+            board.create('segment', [[x,0],[0,1]], {
+              strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+            });
+          }
+        }
+      }else if(division==='horizontal'){
+        for(let i=1;i<n;i++){
+          const y=i/n;
+          if(allowWrong){
+            board.create('segment', [[0,y],[1-y,y]], {
+              strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+            });
+          }else{
+            board.create('segment', [[0,y],[1,0]], {
+              strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+            });
+          }
+        }
+      }else{ // diagonal
+        for(let i=1;i<n;i++){
+          const t=i/n;
+          board.create('segment', [[1-t,t],[0,0]], {
+            strokeColor:'#000', strokeWidth:2, dash:2, highlight:false, fixed:true, cssStyle:'pointer-events:none;'
+          });
+        }
+      }
+      board.create('polygon', [[0,0],[1,0],[0,1]], {
+        borders:{strokeColor:'#333', strokeWidth:6},
+        vertices:{visible:false, name:'', fixed:true, label:{visible:false}},
+        fillColor:'none',
+        highlight:false,
+        fixed:true,
+        hasInnerPoints:false,
+        cssStyle:'pointer-events:none;'
+      });
+    }
+
+    function applyClip(shape){
+      const svg = board?.renderer?.svgRoot;
+      if(!svg) return;
+      if(shape==='triangle'){
+        svg.style.clipPath = 'polygon(-2% 102%, 102% 102%, -2% -2%)';
+      }else if(shape==='rectangle'){
+        svg.style.clipPath = 'polygon(-2% 102%, 102% 102%, 102% -2%, -2% -2%)';
+      }else if(shape==='circle'){
+        svg.style.clipPath = 'circle(45% at 50% 50%)';
+      }else{
+        svg.style.clipPath = '';
+      }
+    }
+
+    shapeSel.addEventListener('change', draw);
+    partsInp.addEventListener('input', draw);
+    divSel.addEventListener('change', draw);
+    filledInp.addEventListener('input', draw);
+    wrongInp.addEventListener('change', draw);
+    minusBtn?.addEventListener('click', () => {
+      let n = parseInt(partsInp.value, 10);
+      n = isNaN(n) ? 1 : Math.max(1, n - 1);
+      partsInp.value = String(n);
+      partsInp.dispatchEvent(new Event('input'));
+    });
+    plusBtn?.addEventListener('click', () => {
+      let n = parseInt(partsInp.value, 10);
+      n = isNaN(n) ? 1 : n + 1;
+      partsInp.value = String(n);
+      partsInp.dispatchEvent(new Event('input'));
+    });
+    btnSvg?.addEventListener('click', () => {
+      const svg = board?.renderer?.svgRoot;
+      if(svg) downloadSVG(svg, `brok${id}.svg`);
+    });
+    btnPng?.addEventListener('click', () => {
+      const svg = board?.renderer?.svgRoot;
+      if(svg) downloadPNG(svg, `brok${id}.png`, 2);
+    });
+    showInp?.addEventListener('change', () => {
+      panel.style.display = showInp.checked ? '' : 'none';
+    });
+    if(showInp && !showInp.checked) panel.style.display='none';
+
+    draw();
+  }
+
+  setupFigure(1);
+  setupFigure(2);
 })();
+


### PR DESCRIPTION
## Summary
- Allow two fraction figures with independent steppers and download buttons
- Add per-figure author settings mirroring Brøkpizza configuration
- Refactor script into reusable `setupFigure` for multiple boards

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b6ec2f0483249187446a65e6e70c