### PR TITLE
Increase curve label offset

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -70,7 +70,7 @@ const ADV = {
     fontSize: 16,
     layer: 30,
     fractions: [0.2, 0.8, 0.6, 0.4],
-    gapPx: 8,
+    gapPx: 12,
     plate: { paddingPx: 4, fill: '#fff', opacity: 0.6, radiusPx: 4 },
     marginFracX: 0.04,
     marginFracY: 0.04


### PR DESCRIPTION
## Summary
- Move curve labels further from graphs by increasing the default gap

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c1b7a90a948324aa254857b49b9cd0