### PR TITLE
Add seven-color palette for fraction visualizations

### DIFF
--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -63,8 +63,8 @@
     .settings label{display:flex;flex-direction:column;font-size:13px;color:#4b5563;}
     .settings input,.settings select{padding:8px 10px;border:1px solid #d1d5db;border-radius:10px;font-size:14px;background:#fff;}
     .checkbox-row{display:flex;align-items:center;gap:6px;}
-    .colors{display:flex;gap:6px;}
-    .colors input{flex:1;min-width:0;}
+    .colors{display:flex;flex-wrap:wrap;gap:6px;}
+    .colors input{flex:1 0 40px;min-width:0;}
     .box svg *:focus{outline:none;}
   </style>
 </head>
@@ -130,10 +130,13 @@
               </label>
               <label>Farger
                 <div class="colors">
-                  <input id="color1_1" type="color" value="#5B2AA5" />
-                  <input id="color1_2" type="color" value="#E4572E" />
-                  <input id="color1_3" type="color" value="#17BEBB" />
-                  <input id="color1_4" type="color" value="#FFC914" />
+                  <input id="color1_1" type="color" value="#d0a3ff" />
+                  <input id="color1_2" type="color" value="#7f3fb7" />
+                  <input id="color1_3" type="color" value="#544869" />
+                  <input id="color1_4" type="color" value="#86658c" />
+                  <input id="color1_5" type="color" value="#b65780" />
+                  <input id="color1_6" type="color" value="#d44b4c" />
+                  <input id="color1_7" type="color" value="#5c3b76" />
                 </div>
               </label>
               <label>Fylte deler (indeks:farge, kommaseparert, klikk på figuren for å fargelegge)
@@ -164,10 +167,13 @@
               </label>
               <label>Farger
                 <div class="colors">
-                  <input id="color2_1" type="color" value="#5B2AA5" />
-                  <input id="color2_2" type="color" value="#E4572E" />
-                  <input id="color2_3" type="color" value="#17BEBB" />
-                  <input id="color2_4" type="color" value="#FFC914" />
+                  <input id="color2_1" type="color" value="#d0a3ff" />
+                  <input id="color2_2" type="color" value="#7f3fb7" />
+                  <input id="color2_3" type="color" value="#544869" />
+                  <input id="color2_4" type="color" value="#86658c" />
+                  <input id="color2_5" type="color" value="#b65780" />
+                  <input id="color2_6" type="color" value="#d44b4c" />
+                  <input id="color2_7" type="color" value="#5c3b76" />
                 </div>
               </label>
               <label>Fylte deler (indeks:farge, kommaseparert, klikk på figuren for å fargelegge)

--- a/brøkvisualiseringer.js
+++ b/brøkvisualiseringer.js
@@ -63,12 +63,12 @@
     const btnPng   = document.getElementById(`btnPng${id}`);
     const showInp  = document.getElementById(`show${id}`);
     const panel    = document.getElementById(`panel${id}`);
-    const colorInputs = [
-      document.getElementById(`color${id}_1`),
-      document.getElementById(`color${id}_2`),
-      document.getElementById(`color${id}_3`),
-      document.getElementById(`color${id}_4`),
-    ];
+    const colorInputs = [];
+    for (let i = 1; ; i++) {
+      const inp = document.getElementById(`color${id}_` + i);
+      if (!inp) break;
+      colorInputs.push(inp);
+    }
     let board;
     let filled = new Map();
 


### PR DESCRIPTION
## Summary
- expand Brøkvisualiseringer color palette to seven colors and wrap color inputs
- detect all available color inputs dynamically

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c20ce8aba8832485edb36825dab61a