### PR TITLE
chore: restore default bar chart values

### DIFF
--- a/diagram.js
+++ b/diagram.js
@@ -2,20 +2,17 @@
    KONFIG – forfatter styrer alt her
    ========================================================= */
 const CFG = {
-  type: 'stacked',
-  title: 'Skjermtid per dag',
-  labels: ['1','2','3','4','5','6','7'],
-  series1: 'Gutter',
-  series2: 'Jenter',
-  start:  [1,6,1,1,2,1,0],
-  start2: [1,3,2,0,2,0,0],
-  answer: [1,6,1,1,2,1,0],
-  answer2:[1,3,2,0,2,0,0],
-  yMax:   9,
+  type: 'bar',
+  title: 'Favorittidretter i 5B',
+  labels: ['Klatring','Fotball','Håndball','Basket','Tennis','Bowling'],
+  series1: '',
+  start:  [6,7,3,5,8,2],
+  answer: [6,7,3,5,8,2],
+  yMax:   8,
   snap:   1,
   tolerance: 0,
-  axisXLabel: 'Timer per dag',
-  axisYLabel: 'Antall personer',
+  axisXLabel: 'Idrett',
+  axisYLabel: 'Antall elever',
   locked: []
 };
 

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -43,17 +43,17 @@
           <label>Type
             <select id="cfgType">
               <option value="line">Linje</option>
-              <option value="bar">Stolpe</option>
+              <option value="bar" selected>Stolpe</option>
               <option value="stacked">Stablede stolper</option>
               <option value="grouped">Grupperte stolper</option>
             </select>
           </label>
           <label>Overskrift
-            <input id="cfgTitle" type="text" value="Skjermtid per dag">
+            <input id="cfgTitle" type="text" value="Favorittidretter i 5B">
           </label>
           <div class="settings-row">
             <label>Etiketter (kommaseparert)
-              <input id="cfgLabels" type="text" value="1,2,3,4,5,6,7">
+              <input id="cfgLabels" type="text" value="Klatring,Fotball,Håndball,Basket,Tennis,Bowling">
             </label>
             <label>Fjern håndtak (0/1, kommaseparert)
               <input id="cfgLocked" type="text" value="">
@@ -61,37 +61,37 @@
           </div>
           <div class="settings-row">
             <label>Serienavn 1
-              <input id="cfgSeries1" type="text" value="Gutter">
+              <input id="cfgSeries1" type="text" value="">
             </label>
             <label>Serienavn 2
-              <input id="cfgSeries2" type="text" value="Jenter">
+              <input id="cfgSeries2" type="text" value="">
             </label>
           </div>
           <div class="settings-row">
             <label>Startverdier 1
-              <input id="cfgStart" type="text" value="1,6,1,1,2,1,0">
+              <input id="cfgStart" type="text" value="6,7,3,5,8,2">
             </label>
             <label>Startverdier 2
-              <input id="cfgStart2" type="text" value="1,3,2,0,2,0,0">
+              <input id="cfgStart2" type="text" value="">
             </label>
           </div>
           <div class="settings-row">
             <label>Fasitverdier 1
-              <input id="cfgAnswer" type="text" value="1,6,1,1,2,1,0">
+              <input id="cfgAnswer" type="text" value="6,7,3,5,8,2">
             </label>
             <label>Fasitverdier 2
-              <input id="cfgAnswer2" type="text" value="1,3,2,0,2,0,0">
+              <input id="cfgAnswer2" type="text" value="">
             </label>
           </div>
           <div class="settings-row">
             <label>Maks y (valgfritt)
-              <input id="cfgYMax" type="text" value="9">
+              <input id="cfgYMax" type="text" value="8">
             </label>
             <label>Navn på x-akse
-              <input id="cfgAxisXLabel" type="text" value="Timer per dag">
+              <input id="cfgAxisXLabel" type="text" value="Idrett">
             </label>
             <label>Navn på y-akse
-              <input id="cfgAxisYLabel" type="text" value="Antall personer">
+              <input id="cfgAxisYLabel" type="text" value="Antall elever">
             </label>
           </div>
           <label>Steg (snap)


### PR DESCRIPTION
## Summary
- revert bar chart defaults to a single-series "Favorittidretter i 5B" example
- adjust diagram settings to match previous sports dataset

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c260470be88324867ec6088eef0b6a