### PR TITLE
Reorder diagram type options to prioritize bar charts

### DIFF
--- a/diagram.js
+++ b/diagram.js
@@ -81,6 +81,13 @@ function initFromCfg(){
     if(!hasTwo && (opt.value==='stacked' || opt.value==='grouped')) opt.disabled = true;
     else opt.disabled = false;
   });
+  const order = hasTwo
+    ? ['bar','grouped','stacked','line']
+    : ['bar','line','grouped','stacked'];
+  order.forEach(val=>{
+    const opt = typeSel.querySelector(`option[value="${val}"]`);
+    if(opt) typeSel.appendChild(opt);
+  });
 
   drawAxesAndGrid();
   drawData();

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -42,10 +42,10 @@
           <div class="settings">
           <label>Type
             <select id="cfgType">
-              <option value="line">Linje</option>
               <option value="bar" selected>Stolpe</option>
-              <option value="stacked">Stablede stolper</option>
+              <option value="line">Linje</option>
               <option value="grouped">Grupperte stolper</option>
+              <option value="stacked">Stablede stolper</option>
             </select>
           </label>
           <label>Overskrift


### PR DESCRIPTION
## Summary
- Place bar chart as the first option in diagram type selector
- Reorder chart type options dynamically; when two data series are present, grouped and stacked bars precede line charts

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c2638a5f9483248fbb0f282ad5aa6a