### PR TITLE
Replace iframe navigation with SPA router

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,11 +23,12 @@
     li { margin: 8px 0; }
     a { color: #147a9c; text-decoration: none; }
     a:hover { text-decoration: underline; }
-    iframe {
-      border: 0;
-      width: 100%;
-      height: 100%;
+
+    #content {
+      padding: 20px;
+      overflow: auto;
     }
+
 
     @media (max-width: 640px) {
       body {
@@ -55,28 +56,18 @@
   <nav>
     <h1>Velg visualisering</h1>
     <ul>
-        <li><a href="graftegner.html" target="content">Graftegner</a></li>
-        <li><a href="nkant.html" target="content">nKant</a></li>
-        <li><a href="diagram/index.html" target="content">Diagram</a></li>
-        <li><a href="brøkpizza.html" target="content">Brøkpizza</a></li>
-        <li><a href="brøkvisualiseringer.html" target="content">Brøkvisualiseringer</a></li>
-        <li><a href="tenkeblokker.html" target="content">Tenkeblokker</a></li>
-        <li><a href="arealmodell0.html" target="content">Arealmodell A</a></li>
-        <li><a href="arealmodellen1.html" target="content">Arealmodell B</a></li>
-        <li><a href="perlesnor.html" target="content">Perlesnor</a></li>
+      <li><a href="/graftegner" onclick="loadPage('/graftegner'); return false;">Graftegner</a></li>
+      <li><a href="/nkant" onclick="loadPage('/nkant'); return false;">nKant</a></li>
+      <li><a href="/diagram" onclick="loadPage('/diagram'); return false;">Diagram</a></li>
+      <li><a href="/brøkpizza" onclick="loadPage('/brøkpizza'); return false;">Brøkpizza</a></li>
+      <li><a href="/brøkvisualiseringer" onclick="loadPage('/brøkvisualiseringer'); return false;">Brøkvisualiseringer</a></li>
+      <li><a href="/tenkeblokker" onclick="loadPage('/tenkeblokker'); return false;">Tenkeblokker</a></li>
+      <li><a href="/arealmodell0" onclick="loadPage('/arealmodell0'); return false;">Arealmodell A</a></li>
+      <li><a href="/arealmodellen1" onclick="loadPage('/arealmodellen1'); return false;">Arealmodell B</a></li>
+      <li><a href="/perlesnor" onclick="loadPage('/perlesnor'); return false;">Perlesnor</a></li>
     </ul>
   </nav>
-    <iframe name="content" title="Innhold"></iframe>
-    <script>
-      const iframe = document.querySelector('iframe');
-      const links = document.querySelectorAll('nav a');
-      const saved = localStorage.getItem('currentPage') || 'nkant.html';
-      iframe.src = saved;
-      links.forEach(link => {
-        link.addEventListener('click', () => {
-          localStorage.setItem('currentPage', link.getAttribute('href'));
-        });
-      });
-    </script>
+  <main id="content"></main>
+  <script type="module" src="router.js"></script>
 </body>
 </html>

--- a/router.js
+++ b/router.js
@@ -1,0 +1,50 @@
+const routes = {
+  '/graftegner': 'graftegner.html',
+  '/nkant': 'nkant.html',
+  '/diagram': 'diagram/index.html',
+  '/brøkpizza': 'brøkpizza.html',
+  '/brøkvisualiseringer': 'brøkvisualiseringer.html',
+  '/tenkeblokker': 'tenkeblokker.html',
+  '/arealmodell0': 'arealmodell0.html',
+  '/arealmodellen1': 'arealmodellen1.html',
+  '/perlesnor': 'perlesnor.html'
+};
+
+async function loadPage(path, addToHistory = true) {
+  const route = decodeURI(path);
+  const fragment = routes[route];
+  const content = document.getElementById('content');
+  if (!fragment) {
+    content.innerHTML = '<p>Siden finnes ikke.</p>';
+    return;
+  }
+  const res = await fetch(fragment);
+  const text = await res.text();
+  const doc = new DOMParser().parseFromString(text, 'text/html');
+  content.innerHTML = doc.body.innerHTML;
+  // execute scripts
+  content.querySelectorAll('script').forEach(oldScript => {
+    const script = document.createElement('script');
+    Array.from(oldScript.attributes).forEach(attr => script.setAttribute(attr.name, attr.value));
+    script.textContent = oldScript.textContent;
+    oldScript.replaceWith(script);
+  });
+  if (addToHistory) {
+    history.pushState({ route }, '', route);
+  }
+}
+
+window.loadPage = loadPage;
+
+function init() {
+  const initial = decodeURI(location.pathname);
+  const path = routes[initial] ? initial : '/nkant';
+  loadPage(path, false);
+}
+
+window.addEventListener('popstate', (e) => {
+  const route = e.state?.route || decodeURI(location.pathname);
+  loadPage(route, false);
+});
+
+init();


### PR DESCRIPTION
## Summary
- Remove iframe layout and add a `<main id="content">` container.
- Switch navigation links to call `loadPage()` and push history entries for each route.
- Add `router.js` to fetch and inject fragments, parse `location.pathname` on load, and handle back/forward navigation.

## Testing
- ⚠️ `npm test` (no tests specified)

------
https://chatgpt.com/codex/tasks/task_e_68c2a816a4888324b1a36f2fb22088cb