### PR TITLE
Add icons and highlight active navigation link

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,8 +21,24 @@
     h1 { font-size: 20px; margin-top: 0; }
     ul { list-style: none; padding: 0; margin: 0; }
     li { margin: 8px 0; }
-    a { color: #147a9c; text-decoration: none; }
-    a:hover { text-decoration: underline; }
+    nav a {
+      color: #147a9c;
+      text-decoration: none;
+      display: flex;
+      gap: 0.5rem;
+      align-items: center;
+      padding: 4px 8px;
+      border-radius: 4px;
+    }
+    nav a:hover { text-decoration: underline; }
+    nav a.active {
+      background: #e5e7eb;
+      font-weight: bold;
+    }
+    nav svg {
+      width: 1.25rem;
+      height: 1.25rem;
+    }
     iframe {
       border: 0;
       width: 100%;
@@ -55,28 +71,18 @@
   <nav>
     <h1>Velg visualisering</h1>
     <ul>
-        <li><a href="graftegner.html" target="content">Graftegner</a></li>
-        <li><a href="nkant.html" target="content">nKant</a></li>
-        <li><a href="diagram/index.html" target="content">Diagram</a></li>
-        <li><a href="brøkpizza.html" target="content">Brøkpizza</a></li>
-        <li><a href="brøkvisualiseringer.html" target="content">Brøkvisualiseringer</a></li>
-        <li><a href="tenkeblokker.html" target="content">Tenkeblokker</a></li>
-        <li><a href="arealmodell0.html" target="content">Arealmodell A</a></li>
-        <li><a href="arealmodellen1.html" target="content">Arealmodell B</a></li>
-        <li><a href="perlesnor.html" target="content">Perlesnor</a></li>
+        <li><a href="graftegner.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m16.862 4.487 1.687-1.688a1.875 1.875 0 1 1 2.652 2.652L10.582 16.07a4.5 4.5 0 0 1-1.897 1.13L6 18l.8-2.685a4.5 4.5 0 0 1 1.13-1.897l8.932-8.931Zm0 0L19.5 7.125M18 14v4.75A2.25 2.25 0 0 1 15.75 21H5.25A2.25 2.25 0 0 1 3 18.75V8.25A2.25 2.25 0 0 1 5.25 6H10"/></svg>Graftegner</a></li>
+        <li><a href="nkant.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="m21 7.5-9-5.25L3 7.5m18 0-9 5.25m9-5.25v9l-9 5.25M3 7.5l9 5.25M3 7.5v9l9 5.25m0-9v9"/></svg>nKant</a></li>
+        <li><a href="diagram/index.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/></svg>Diagram</a></li>
+        <li><a href="brøkpizza.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z"/></svg>Brøkpizza</a></li>
+        <li><a href="brøkvisualiseringer.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6 6.878V6a2.25 2.25 0 0 1 2.25-2.25h7.5A2.25 2.25 0 0 1 18 6v.878m-12 0c.235-.083.487-.128.75-.128h10.5c.263 0 .515.045.75.128m-12 0A2.25 2.25 0 0 0 4.5 9v.878m13.5-3A2.25 2.25 0 0 1 19.5 9v.878m0 0a2.246 2.246 0 0 0-.75-.128H5.25c-.263 0-.515.045-.75.128m15 0A2.25 2.25 0 0 1 21 12v6a2.25 2.25 0 0 1-2.25 2.25H5.25A2.25 2.25 0 0 1 3 18v-6c0-.98.626-1.813 1.5-2.122"/></svg>Brøkvisualiseringer</a></li>
+        <li><a href="tenkeblokker.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M14.25 6.087c0-.355.186-.676.401-.959.221-.29.349-.634.349-1.003 0-1.036-1.007-1.875-2.25-1.875s-2.25.84-2.25 1.875c0 .369.128.713.349 1.003.215.283.401.604.401.959v0a.64.64 0 0 1-.657.643 48.39 48.39 0 0 1-4.163-.3c.186 1.613.293 3.25.315 4.907a.656.656 0 0 1-.658.663v0c-.355 0-.676-.186-.959-.401a1.647 1.647 0 0 0-1.003-.349c-1.036 0-1.875 1.007-1.875 2.25s.84 2.25 1.875 2.25c.369 0 .713-.128 1.003-.349.283-.215.604-.401.959-.401v0c.31 0 .555.26.532.57a48.039 48.039 0 0 1-.642 5.056c1.518.19 3.058.309 4.616.354a.64.64 0 0 0 .657-.643v0c0-.355-.186-.676-.401-.959a1.647 1.647 0 0 1-.349-1.003c0-1.035 1.008-1.875 2.25-1.875 1.243 0 2.25.84 2.25 1.875 0 .369-.128.713-.349 1.003-.215.283-.4.604-.4.959v0c0 .333.277.599.61.58a48.1 48.1 0 0 0 5.427-.63 48.05 48.05 0 0 0 .582-4.717.532.532 0 0 0-.533-.57v0c-.355 0-.676.186-.959.401-.29.215-.634.349-1.003.349-1.035 0-1.875-1.007-1.875-2.25s.84-2.25 1.875-2.25c.37 0 .713.128 1.003.349.283.215.604.401.96.401v0a.656.656 0 0 0 .658-.663 48.422 48.422 0 0 0-.37-5.36c-1.886.342-3.81.574-5.766.689a.578.578 0 0 1-.61-.58v0Z"/></svg>Tenkeblokker</a></li>
+        <li><a href="arealmodell0.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M16.5 8.25V6a2.25 2.25 0 0 0-2.25-2.25H6A2.25 2.25 0 0 0 3.75 6v8.25A2.25 2.25 0 0 0 6 16.5h2.25m8.25-8.25H18a2.25 2.25 0 0 1 2.25 2.25V18A2.25 2.25 0 0 1 18 20.25h-7.5A2.25 2.25 0 0 1 8.25 18v-1.5m8.25-8.25h-6a2.25 2.25 0 0 0-2.25 2.25v6"/></svg>Arealmodell A</a></li>
+        <li><a href="arealmodellen1.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M9 4.5v15m6-15v15m-10.875 0h15.75c.621 0 1.125-.504 1.125-1.125V5.625c0-.621-.504-1.125-1.125-1.125H4.125C3.504 4.5 3 5.004 3 5.625v12.75c0 .621.504 1.125 1.125 1.125Z"/></svg>Arealmodell B</a></li>
+        <li><a href="perlesnor.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M6.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM12.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0ZM18.75 12a.75.75 0 1 1-1.5 0 .75.75 0 0 1 1.5 0Z"/></svg>Perlesnor</a></li>
     </ul>
   </nav>
     <iframe name="content" title="Innhold"></iframe>
-    <script>
-      const iframe = document.querySelector('iframe');
-      const links = document.querySelectorAll('nav a');
-      const saved = localStorage.getItem('currentPage') || 'nkant.html';
-      iframe.src = saved;
-      links.forEach(link => {
-        link.addEventListener('click', () => {
-          localStorage.setItem('currentPage', link.getAttribute('href'));
-        });
-      });
-    </script>
+    <script src="router.js"></script>
 </body>
 </html>

--- a/router.js
+++ b/router.js
@@ -1,0 +1,20 @@
+const iframe = document.querySelector('iframe');
+const links = document.querySelectorAll('nav a');
+const saved = localStorage.getItem('currentPage') || 'nkant.html';
+iframe.src = saved;
+
+function setActive(current) {
+  links.forEach(link => {
+    link.classList.toggle('active', link.getAttribute('href') === current);
+  });
+}
+
+setActive(saved);
+
+links.forEach(link => {
+  link.addEventListener('click', () => {
+    const href = link.getAttribute('href');
+    localStorage.setItem('currentPage', href);
+    setActive(href);
+  });
+});


### PR DESCRIPTION
## Summary
- Integrate Heroicons to display SVG icons beside each navigation link.
- Implement router logic to persist current page and apply an `active` class to the selected link.
- Style navigation with flexbox and an `.active` state for improved alignment and visibility.

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a818f6c08324b6c11b6d30c9946c