### PR TITLE
Improve fraction visualizer figure management

### DIFF
--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -20,14 +20,28 @@
     @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
     .grid2{
-      display:grid;
-      grid-template-columns:repeat(2,minmax(0,1fr));
+      display:flex;
+      flex-wrap:wrap;
       gap:24px;
+      justify-content:center;
       align-items:start;
     }
     .figurePanel{display:grid;place-items:center;gap:10px;}
+    .addFigureBtn{
+      width:clamp(100px,40vw,420px);
+      aspect-ratio:1;
+      border:2px dashed #cfcfcf;
+      border-radius:10px;
+      background:#fff;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      font-size:48px;
+      color:#6b7280;
+      cursor:pointer;
+    }
     @media(max-width:420px){
-      .grid2{grid-template-columns:1fr;gap:16px;}
+      .grid2{flex-direction:column;gap:16px;}
       .figure .box{width:clamp(240px,92vw,420px);}
     }
     .card{
@@ -58,6 +72,7 @@
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
     .btn:active{transform:translateY(1px)}
     .settings{display:flex;gap:var(--gap);}
+    .card>fieldset{display:flex;flex-direction:column;gap:8px;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;}
     .settings fieldset{flex:1;display:flex;flex-direction:column;gap:8px;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;}
     legend{font-weight:600;font-size:13px;color:#374151;padding:0 4px;}
     .settings label{display:flex;flex-direction:column;font-size:13px;color:#4b5563;}
@@ -82,6 +97,7 @@
               <button id="partsPlus1" type="button" aria-label="Flere deler">+</button>
             </div>
           </div>
+          <button id="addFigure" class="addFigureBtn" type="button" aria-label="Legg til figur">+</button>
           <div id="panel2" class="figurePanel" style="display:none">
             <div class="figure"><div id="box2" class="box"></div></div>
             <div class="stepper" aria-label="Antall deler">
@@ -106,6 +122,21 @@
         </div>
         <div class="card">
           <h2>Forfatters innstillinger</h2>
+          <fieldset>
+            <legend>Farger</legend>
+            <label>Antall farger
+              <input id="colorCount" type="number" min="1" max="7" value="7" />
+            </label>
+            <div class="colors">
+              <input id="color_1" type="color" value="#d0a3ff" />
+              <input id="color_2" type="color" value="#7f3fb7" />
+              <input id="color_3" type="color" value="#544869" />
+              <input id="color_4" type="color" value="#86658c" />
+              <input id="color_5" type="color" value="#b65780" />
+              <input id="color_6" type="color" value="#d44b4c" />
+              <input id="color_7" type="color" value="#5c3b76" />
+            </div>
+          </fieldset>
           <div class="settings">
             <fieldset>
               <legend>Figur 1</legend>
@@ -130,23 +161,9 @@
                   <option value="triangular">trekantsrutenett</option>
                 </select>
               </label>
-              <label>Farger
-                <div class="colors">
-                  <input id="color1_1" type="color" value="#d0a3ff" />
-                  <input id="color1_2" type="color" value="#7f3fb7" />
-                  <input id="color1_3" type="color" value="#544869" />
-                  <input id="color1_4" type="color" value="#86658c" />
-                  <input id="color1_5" type="color" value="#b65780" />
-                  <input id="color1_6" type="color" value="#d44b4c" />
-                  <input id="color1_7" type="color" value="#5c3b76" />
-                </div>
-              </label>
-              <label>Fylte deler (indeks:farge, kommaseparert, klikk på figuren for å fargelegge)
-                <input id="filled1" type="text" value="0:1" />
-              </label>
               <div class="checkbox-row"><input id="allowWrong1" type="checkbox" /><label for="allowWrong1">Tillat gale illustrasjoner</label></div>
             </fieldset>
-            <fieldset>
+            <fieldset id="fieldset2" style="display:none">
               <legend>Figur 2</legend>
               <div class="checkbox-row"><input id="show2" type="checkbox"><label for="show2">Vis</label></div>
               <label>Form
@@ -168,20 +185,6 @@
                   <option value="grid">horisontalt og vertikalt</option>
                   <option value="triangular">trekantsrutenett</option>
                 </select>
-              </label>
-              <label>Farger
-                <div class="colors">
-                  <input id="color2_1" type="color" value="#d0a3ff" />
-                  <input id="color2_2" type="color" value="#7f3fb7" />
-                  <input id="color2_3" type="color" value="#544869" />
-                  <input id="color2_4" type="color" value="#86658c" />
-                  <input id="color2_5" type="color" value="#b65780" />
-                  <input id="color2_6" type="color" value="#d44b4c" />
-                  <input id="color2_7" type="color" value="#5c3b76" />
-                </div>
-              </label>
-              <label>Fylte deler (indeks:farge, kommaseparert, klikk på figuren for å fargelegge)
-                <input id="filled2" type="text" value="0:1" />
               </label>
               <div class="checkbox-row"><input id="allowWrong2" type="checkbox" /><label for="allowWrong2">Tillat gale illustrasjoner</label></div>
             </fieldset>


### PR DESCRIPTION
## Summary
- Add global color palette with adjustable color count shared across figures
- Replace second figure settings with optional add-figure button and ensure spacing between figures
- Remove "filled parts" field and keep per-figure SVG/PNG export buttons

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a7e522708324991ec0823be0fd8a