### PR TITLE
Reduce add figure add button size

### DIFF
--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -23,12 +23,12 @@
       display:flex;
       flex-wrap:wrap;
       gap:24px;
-      justify-content:center;
+      justify-content:flex-start;
       align-items:start;
     }
     .figurePanel{display:grid;place-items:center;gap:10px;}
     .addFigureBtn{
-      width:clamp(100px,40vw,420px);
+      width:clamp(80px,20vw,160px);
       aspect-ratio:1;
       border:2px dashed #cfcfcf;
       border-radius:10px;


### PR DESCRIPTION
## Summary
- Reduce "add figure" button footprint to leave more room for the first figure
- Align figures and the add box horizontally on initial load

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ada4efa883249d3bbb81d28de510