### PR TITLE
Disable caching for development server

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "arealmodell0.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "npx http-server"
+    "start": "npx http-server -c-1"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## Summary
- disable caching by updating `npm start` to run `http-server` with `-c-1`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` and `curl -I localhost:8080`

------
https://chatgpt.com/codex/tasks/task_e_68c2b0f1c1b48324aaee01ab6727330f