### PR TITLE
Combine axis name inputs into single row

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -37,6 +37,8 @@
     .settings-row label.points{ flex:0 0 70px; }
     .settings-row label.checkbox-label{ flex:1 1 200px; }
     .checkbox-label{ flex-direction:row; align-items:center; gap:6px; white-space:normal; }
+    .axis-names{ gap:12px; align-items:center; }
+    .axis-label{ flex-direction:row; align-items:center; gap:4px; }
   </style>
 </head>
 <body>
@@ -77,11 +79,12 @@
             <label class="checkbox-label"><input id="cfgLock" type="checkbox"> Lås forhold 1:1 (krever screen)</label>
             <label class="checkbox-label"><input id="cfgPan" type="checkbox"> Tillat pan</label>
           </div>
-          <div class="settings-row">
-            <label>Navn på x-akse (valgfritt)
+          <div class="settings-row axis-names">
+            <label>Navn på akser</label>
+            <label class="axis-label">x:
               <input id="cfgAxisX" type="text" value="x">
             </label>
-            <label>Navn på y-akse (valgfritt)
+            <label class="axis-label">y:
               <input id="cfgAxisY" type="text" value="y">
             </label>
           </div>


### PR DESCRIPTION
## Summary
- Combine x and y axis labels into a single "Navn på akser" row in `graftegner.html`
- Add `.axis-names` and `.axis-label` styles to keep axis name inputs on one line and align labels horizontally

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c2b117fe7c8324ad1ea85c1c491f34