### PR TITLE
Remove redundant visualization headings

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -52,7 +52,6 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <h2>Arealmodell</h2>
         <div id="box" class="jxgbox" aria-label="Arealmodell rektangel"></div>
         <div class="toolbar">
           <button id="btnReset" class="btn" type="button">Reset</button>

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -62,7 +62,6 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <h2>Arealmodell</h2>
         <svg id="area" preserveAspectRatio="xMidYMid meet" aria-label="Arealmodell"></svg>
       </div>
       <div class="side">

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -82,7 +82,6 @@
     <div class="grid">
 
       <div class="card">
-        <h2>Brøksirkler</h2>
         <div class="grid2">
           <!-- Pizza 1 -->
           <div id="panel1" class="pizzaPanel">

--- a/brøkvisualiseringer.html
+++ b/brøkvisualiseringer.html
@@ -87,7 +87,6 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <h2>Figurer</h2>
         <div class="grid2">
           <div id="panel1" class="figurePanel">
             <div class="figure"><div id="box1" class="box"></div></div>

--- a/graftegner.html
+++ b/graftegner.html
@@ -45,7 +45,6 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <h2>Graf</h2>
         <div class="figure">
           <div id="board" aria-label="JSXGraph-tavle"></div>
         </div>

--- a/nkant.html
+++ b/nkant.html
@@ -39,7 +39,6 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <h2>Figur(er)</h2>
         <div class="figure">
           <svg id="paper" viewBox="0 0 600 420" preserveAspectRatio="xMidYMid meet" aria-label=""></svg>
         </div>

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -58,7 +58,6 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <h2>Perlesnor</h2>
         <div class="figure">
           <svg id="beadSVG" viewBox="0 0 1400 460" role="img" aria-label="Perlesnor med klype"></svg>
           <p id="beadHelp" hidden>


### PR DESCRIPTION
## Summary
- strip redundant "Graf", "Figur(er)", "Figurer", "Brøksirkler", "Arealmodell", and "Perlesnor" headings from visualization pages
- preserve existing menus and download/settings sections

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c2b89fb3708324ba33419dbe823e0f