### PR TITLE
Fix square and rectangle freeform parsing

### DIFF
--- a/nkant.js
+++ b/nkant.js
@@ -175,14 +175,14 @@ function parseSpecFreeform(str){
   });
   if(/kvadrat/.test(text)){
     const s = nums[0] ?? 1;
-    Object.assign(out, {a:s, b:s, c:s, d:s, B:90, D:90});
+    Object.assign(out, {a:s, b:s, c:s, d:s, B:90});
     return out;
   }
 
   if(/rektangel/.test(text)){
     const w = nums[0] ?? 1;
     const h = nums[1] ?? w;
-    Object.assign(out, {a:w, c:w, b:h, d:h, B:90, D:90});
+    Object.assign(out, {a:w, c:w, b:h, d:h, B:90});
     return out;
   }
 


### PR DESCRIPTION
## Summary
- Avoid unsupported angle combinations when interpreting "kvadrat" or "rektangel" in freeform specs by setting only a single right angle.

## Testing
- `node` script verifying `parseSpecFreeform` outputs for square and rectangle
- `node` script confirming `drawQuadToGroup` runs without error for a square
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c2de7657ac8324b7eac52a9fe24f64