### PR TITLE
Add controls for setting bead counts

### DIFF
--- a/kuler.html
+++ b/kuler.html
@@ -12,6 +12,9 @@
       background: #f7f8fb;
       color: #111827;
     }
+    #controls label {
+      margin-right: 1rem;
+    }
     svg {
       width: 100%;
       height: auto;
@@ -19,6 +22,14 @@
   </style>
 </head>
 <body>
+  <div id="controls">
+    <label>Røde kuler:
+      <input id="redCount" type="number" min="0" value="4" />
+    </label>
+    <label>Blå kuler:
+      <input id="blueCount" type="number" min="0" value="4" />
+    </label>
+  </div>
   <svg id="bowlSVG"></svg>
   <script src="kuler.js"></script>
 </body>

--- a/kuler.js
+++ b/kuler.js
@@ -53,7 +53,12 @@ svg.appendChild(gBowls);
 /* ============ STATE ============ */
 const bowls = [];
 
-render();
+const redInput = document.getElementById("redCount");
+const blueInput = document.getElementById("blueCount");
+redInput.addEventListener("input", updateFromInputs);
+blueInput.addEventListener("input", updateFromInputs);
+
+updateFromInputs();
 
 /* ============ FUNKSJONER ============ */
 function render(){
@@ -85,6 +90,18 @@ function render(){
     gBowls.appendChild(g);
     bowls.push({group:g, beads:gBeads, cfg:bCfg});
   });
+}
+
+function updateFromInputs(){
+  const red = parseInt(redInput.value) || 0;
+  const blue = parseInt(blueInput.value) || 0;
+  const bowl = SIMPLE.bowls[0];
+  bowl.colorCounts = [
+    { color: "red", count: red },
+    { color: "blue", count: blue }
+  ];
+  CFG = makeCFG();
+  render();
 }
 
 /* ===== helpers ===== */


### PR DESCRIPTION
## Summary
- Allow users to input the number of red and blue beads
- Update rendering logic to rebuild bowl when counts change

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e36cbe7c8324a20e48a6ad7f3d6a