### PR TITLE
Add circle option for Figurtall grid

### DIFF
--- a/figurtall.html
+++ b/figurtall.html
@@ -67,6 +67,13 @@
       background:#fff;
       cursor:pointer;
     }
+    .box.circle{
+      gap:2px;
+    }
+    .box.circle .cell{
+      border-radius:50%;
+      border:none;
+    }
     .stepper{
       display:flex;align-items:center;gap:12px;
       padding:6px 10px;border:1px solid #cfcfcf;border-radius:12px;
@@ -107,6 +114,7 @@
               <span id="sizeVal">10</span>
               <button id="sizePlus" type="button" aria-label="Flere ruter">+</button>
             </div>
+            <label><input id="circleMode" type="checkbox" /> Bruk sirkler</label>
           </fieldset>
           <fieldset>
             <legend>Farger</legend>

--- a/figurtall.js
+++ b/figurtall.js
@@ -1,6 +1,7 @@
 (function(){
   const boxes=[];
   let size=10;
+  let circleMode=false;
 
   const colorCountInp=document.getElementById('colorCount');
   const colorInputs=[];
@@ -70,6 +71,17 @@
     updateCellColors();
   }
 
+  function updateShape(){
+    boxes.forEach(box=>box.classList.toggle('circle',circleMode));
+  }
+
+  const circleInp=document.getElementById('circleMode');
+  circleMode=!!circleInp?.checked;
+  circleInp?.addEventListener('change',()=>{
+    circleMode=circleInp.checked;
+    updateShape();
+  });
+
   const container=document.getElementById('figureContainer');
   const addBtn=document.getElementById('addFigure');
   let figureCount=0;
@@ -86,6 +98,7 @@
     const box=panel.querySelector('.box');
     boxes.push(box);
     createGrid(box);
+    box.classList.toggle('circle',circleMode);
     container.insertBefore(panel,addBtn);
   }
 


### PR DESCRIPTION
## Summary
- allow toggling grid cells between squares and circles
- style circular cells and apply setting to existing and new figures

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c2f2643e0c83248a5e83c2bba1d286