### PR TITLE
Add grid visibility toggle to Figurtall

### DIFF
--- a/figurtall.html
+++ b/figurtall.html
@@ -71,6 +71,9 @@
       background:#fff;
       cursor:pointer;
     }
+    .box.hide-grid .cell{
+      border:none;
+    }
     .row.offset{
       transform:translateX(calc(var(--cellSize)/2));
     }
@@ -127,6 +130,7 @@
                 <button id="colsPlus" type="button" aria-label="Flere kolonner">+</button>
               </div>
             </label>
+            <label><input id="showGrid" type="checkbox" checked /> Vis rutenett</label>
             <label><input id="offsetRows" type="checkbox" /> Forskyv annenhver rad</label>
             <label><input id="circleMode" type="checkbox" /> Bruk sirkler</label>
           </fieldset>

--- a/figurtall.js
+++ b/figurtall.js
@@ -4,6 +4,7 @@
   let cols=10;
   let circleMode=false;
   let offset=false;
+  let showGrid=true;
 
   const colorCountInp=document.getElementById('colorCount');
   const colorInputs=[];
@@ -65,6 +66,7 @@
     el.style.setProperty('--rows',rows);
     el.style.setProperty('--aspect',rows/cols);
     el.style.setProperty('--cellSize',(100/cols)+'%');
+    el.classList.toggle('hide-grid', !showGrid);
     for(let r=0;r<rows;r++){
       const row=document.createElement('div');
       row.className='row';
@@ -87,9 +89,16 @@
     }
   }
 
+  function updateGridVisibility(){
+    boxes.forEach(box=>{
+      box.classList.toggle('hide-grid', !showGrid);
+    });
+  }
+
   function redrawAll(){
     boxes.forEach(box=>createGrid(box));
     updateCellColors();
+    updateGridVisibility();
   }
 
   const circleInp=document.getElementById('circleMode');
@@ -104,6 +113,13 @@
   offsetInp?.addEventListener('change',()=>{
     offset=offsetInp.checked;
     redrawAll();
+  });
+
+  const gridInp=document.getElementById('showGrid');
+  showGrid=!!gridInp?.checked;
+  gridInp?.addEventListener('change',()=>{
+    showGrid=gridInp.checked;
+    updateGridVisibility();
   });
 
   const container=document.getElementById('figureContainer');


### PR DESCRIPTION
## Summary
- add checkbox to show or hide grid lines in Figurtall figures
- support responsive grid line visibility through new `hide-grid` styling

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c2fd465db48324a799497b4d8e7234