### PR TITLE
feat: apply standard color palette

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -124,15 +124,15 @@
           <fieldset>
             <legend>Farger</legend>
             <label>Antall farger
-              <input id="colorCount" type="number" min="1" max="6" value="6" />
+              <input id="colorCount" type="number" min="1" max="6" value="1" />
             </label>
             <div class="colors">
-              <input id="color_1" type="color" value="#d0a3ff" />
-              <input id="color_2" type="color" value="#7f3fb7" />
-              <input id="color_3" type="color" value="#544869" />
-              <input id="color_4" type="color" value="#86658c" />
-              <input id="color_5" type="color" value="#b65780" />
-              <input id="color_6" type="color" value="#d44b4c" />
+              <input id="color_1" type="color" value="#6C1BA2" />
+              <input id="color_2" type="color" value="#534477" />
+              <input id="color_3" type="color" value="#BF4474" />
+              <input id="color_4" type="color" value="#B25FE3" />
+              <input id="color_5" type="color" value="#873E79" />
+              <input id="color_6" type="color" value="#E31C3D" />
             </div>
           </fieldset>
           <div class="settings">

--- a/brøkfigurer.js
+++ b/brøkfigurer.js
@@ -58,11 +58,26 @@
     if(!inp) break;
     colorInputs.push(inp);
   }
-  let colorCount = parseInt(colorCountInp?.value,10) || colorInputs.length;
+  const DEFAULT_COLOR_SETS = {
+    1:['#6C1BA2'],
+    2:['#534477','#BF4474'],
+    3:['#534477','#6C1BA2','#BF4474'],
+    4:['#534477','#B25FE3','#6C1BA2','#BF4474'],
+    5:['#534477','#B25FE3','#6C1BA2','#873E79','#BF4474'],
+    6:['#534477','#B25FE3','#6C1BA2','#873E79','#BF4474','#E31C3D']
+  };
+  function setDefaultColors(n){
+    const arr = DEFAULT_COLOR_SETS[n] || DEFAULT_COLOR_SETS[6];
+    colorInputs.forEach((inp,idx)=>{
+      if(arr[idx]) inp.value = arr[idx];
+    });
+  }
+  let colorCount = parseInt(colorCountInp?.value,10) || 1;
   function getColors(){
     return colorInputs.slice(0,colorCount).map(inp=>inp.value);
   }
   function updateColorVisibility(){
+    setDefaultColors(colorCount);
     colorInputs.forEach((inp,idx)=>{
       inp.style.display = idx < colorCount ? '' : 'none';
     });

--- a/figurtall.html
+++ b/figurtall.html
@@ -133,15 +133,15 @@
           <fieldset>
             <legend>Farger</legend>
             <label>Antall farger
-              <input id="colorCount" type="number" min="1" max="6" value="6" />
+              <input id="colorCount" type="number" min="1" max="6" value="1" />
             </label>
             <div class="colors">
-              <input id="color_1" type="color" value="#d0a3ff" />
-              <input id="color_2" type="color" value="#7f3fb7" />
-              <input id="color_3" type="color" value="#544869" />
-              <input id="color_4" type="color" value="#86658c" />
-              <input id="color_5" type="color" value="#b65780" />
-              <input id="color_6" type="color" value="#d44b4c" />
+              <input id="color_1" type="color" value="#6C1BA2" />
+              <input id="color_2" type="color" value="#534477" />
+              <input id="color_3" type="color" value="#BF4474" />
+              <input id="color_4" type="color" value="#B25FE3" />
+              <input id="color_5" type="color" value="#873E79" />
+              <input id="color_6" type="color" value="#E31C3D" />
             </div>
           </fieldset>
         </div>

--- a/figurtall.js
+++ b/figurtall.js
@@ -12,7 +12,21 @@
     if(!inp) break;
     colorInputs.push(inp);
   }
-  let colorCount=parseInt(colorCountInp?.value,10)||colorInputs.length;
+  const DEFAULT_COLOR_SETS={
+    1:['#6C1BA2'],
+    2:['#534477','#BF4474'],
+    3:['#534477','#6C1BA2','#BF4474'],
+    4:['#534477','#B25FE3','#6C1BA2','#BF4474'],
+    5:['#534477','#B25FE3','#6C1BA2','#873E79','#BF4474'],
+    6:['#534477','#B25FE3','#6C1BA2','#873E79','#BF4474','#E31C3D']
+  };
+  function setDefaultColors(n){
+    const arr=DEFAULT_COLOR_SETS[n]||DEFAULT_COLOR_SETS[6];
+    colorInputs.forEach((inp,idx)=>{
+      if(arr[idx]) inp.value=arr[idx];
+    });
+  }
+  let colorCount=parseInt(colorCountInp?.value,10)||1;
 
   function getColors(){
     return colorInputs.slice(0,colorCount).map(inp=>inp.value);
@@ -46,6 +60,7 @@
   }
 
   function updateColorVisibility(){
+    setDefaultColors(colorCount);
     colorInputs.forEach((inp,idx)=>{
       inp.style.display=idx<colorCount?'':'none';
     });


### PR DESCRIPTION
## Summary
- default single-color figures to purple `#6C1BA2`
- preload multi-color palette for fraction and figure visualizations
- start visualizations with one color enabled

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c2fe296084832493ef5bcc672a7e5b