### PR TITLE
Ensure figurtall uses square cells and a 4x4 default grid

### DIFF
--- a/figurtall.html
+++ b/figurtall.html
@@ -119,14 +119,14 @@
             <label>Rader
               <div class="stepper" aria-label="Antall ruter i høyden">
                 <button id="rowsMinus" type="button" aria-label="Færre rader">&minus;</button>
-                <span id="rowsVal">10</span>
+                <span id="rowsVal">4</span>
                 <button id="rowsPlus" type="button" aria-label="Flere rader">+</button>
               </div>
             </label>
             <label>Kolonner
               <div class="stepper" aria-label="Antall ruter i bredden">
                 <button id="colsMinus" type="button" aria-label="Færre kolonner">&minus;</button>
-                <span id="colsVal">10</span>
+                <span id="colsVal">4</span>
                 <button id="colsPlus" type="button" aria-label="Flere kolonner">+</button>
               </div>
             </label>

--- a/figurtall.js
+++ b/figurtall.js
@@ -1,7 +1,8 @@
 (function(){
   const boxes=[];
-  let rows=10;
-  let cols=10;
+  // Default grid size set to 4x4
+  let rows=4;
+  let cols=4;
   let circleMode=false;
   let offset=false;
   let showGrid=true;
@@ -79,7 +80,8 @@
     el.innerHTML='';
     el.style.setProperty('--cols',cols);
     el.style.setProperty('--rows',rows);
-    el.style.setProperty('--aspect',rows/cols);
+    // Maintain square cells by ensuring width/height ratio equals cols/rows
+    el.style.setProperty('--aspect',cols/rows);
     el.style.setProperty('--cellSize',(100/cols)+'%');
     el.classList.toggle('hide-grid', !showGrid);
     for(let r=0;r<rows;r++){


### PR DESCRIPTION
## Summary
- default figurtall grid starts at 4×4 cells
- correct aspect ratio to keep cells square when rows and columns differ
- update UI labels to display new defaults

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c301485c2883248eb474cd91fbe9bf