### PR TITLE
Improve navigation accessibility with focus styles and ARIA

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,10 @@
       background: #e5e7eb;
       font-weight: bold;
     }
+    nav a:focus, nav a:focus-visible {
+      outline: 2px solid #111827;
+      outline-offset: 2px;
+    }
     nav svg {
       width: 1.25rem;
       height: 1.25rem;

--- a/router.js
+++ b/router.js
@@ -5,7 +5,13 @@ iframe.src = saved;
 
 function setActive(current) {
   nav.querySelectorAll('a').forEach(link => {
-    link.classList.toggle('active', link.getAttribute('href') === current);
+    const isActive = link.getAttribute('href') === current;
+    link.classList.toggle('active', isActive);
+    if (isActive) {
+      link.setAttribute('aria-current', 'page');
+    } else {
+      link.removeAttribute('aria-current');
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- add focus-visible outline styles to navigation links for better keyboard use
- toggle `aria-current` on active navigation links to convey current page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c302981e6c83249b0846d09e6f6172