### PR TITLE
Preserve cell colors when resizing grid

### DIFF
--- a/figurtall.js
+++ b/figurtall.js
@@ -77,6 +77,15 @@
   updateColorVisibility();
 
   function createGrid(el){
+    // Store existing colors before rebuilding the grid
+    const prevColors=[];
+    el.querySelectorAll('.row').forEach((row,r)=>{
+      prevColors[r]=[];
+      row.querySelectorAll('.cell').forEach((cell,c)=>{
+        prevColors[r][c]=cell.dataset.color||'0';
+      });
+    });
+
     el.innerHTML='';
     el.style.setProperty('--cols',cols);
     el.style.setProperty('--rows',rows);
@@ -91,7 +100,8 @@
       for(let c=0;c<cols;c++){
         const cell=document.createElement('div');
         cell.className='cell';
-        cell.dataset.color='0';
+        // Restore previously set color if available
+        cell.dataset.color=prevColors?.[r]?.[c]||'0';
         cell.addEventListener('click',()=>{
           const colors=getColors();
           let idx=parseInt(cell.dataset.color,10)||0;


### PR DESCRIPTION
## Summary
- retain existing cell colors when resizing grids in Figurtall

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c30d6149a88324885f0c819ea3b761