### PR TITLE
Remove redundant Figurer heading

### DIFF
--- a/figurtall.html
+++ b/figurtall.html
@@ -99,7 +99,6 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <h2>Figurer</h2>
         <div id="figureContainer" class="grid2">
           <button id="addFigure" class="addFigureBtn" type="button" aria-label="Legg til figur">+</button>
         </div>


### PR DESCRIPTION
## Summary
- remove unnecessary "Figurer" heading from figurtall interface

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c30e704cd083248f0c0ccca9bc4d8d