### PR TITLE
feat: add bead size control

### DIFF
--- a/kuler.js
+++ b/kuler.js
@@ -61,6 +61,19 @@ svg.appendChild(gBowls);
 const bowls = [];
 const controls = document.getElementById("controls");
 const inputs = {};
+const sizeLabel = document.createElement("label");
+sizeLabel.textContent = "Kulestørrelse";
+const sizeInput = document.createElement("input");
+sizeInput.type = "number";
+sizeInput.min = "1";
+sizeInput.value = ADV.beadRadius;
+sizeLabel.appendChild(sizeInput);
+controls.appendChild(sizeLabel);
+sizeInput.addEventListener("input", () => {
+  ADV.beadRadius = parseFloat(sizeInput.value) || 0;
+  CFG = makeCFG();
+  render();
+});
 Object.keys(ADV.assets.beads).forEach(color => {
   const label = document.createElement("label");
   label.textContent = `${cap(color)} kuler`;


### PR DESCRIPTION
## Summary
- allow bead size adjustment via a new input in the controls panel
- update rendering to react to bead size changes

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c310b5a6208324bce27cd431e41a4e