### PR TITLE
Fix bead dragging in Kuler example

### DIFF
--- a/kuler.html
+++ b/kuler.html
@@ -23,11 +23,12 @@
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
     .figure{border-radius:10px;background:#fff;overflow:hidden;border:1px solid #eef0f3;}
-    .figure svg{width:100%;height:auto;display:block;}
+    .figure svg{width:100%;height:auto;display:block;touch-action:none;}
     .ctrlRow{display:flex;align-items:center;gap:6px;font-size:14px;}
     .ctrlRow button{border:1px solid #d1d5db;border-radius:6px;background:#fff;width:24px;height:24px;line-height:1;}
     .ctrlRow .count{width:24px;text-align:center;}
     .bead{cursor:grab;}
+    .bead:active{cursor:grabbing;}
     .beadShadow{filter:drop-shadow(0 1px 1px rgba(0,0,0,.25));}
   </style>
 </head>

--- a/kuler.js
+++ b/kuler.js
@@ -154,6 +154,8 @@ function startDrag(e){
   dragOffY = pt.y - y;
   svg.addEventListener("pointermove", onDrag);
   svg.addEventListener("pointerup", endDrag);
+  svg.addEventListener("pointercancel", endDrag);
+  try{svg.setPointerCapture(e.pointerId);}catch(_){}
 }
 
 function onDrag(e){
@@ -163,9 +165,11 @@ function onDrag(e){
   dragBead.setAttribute("y", pt.y - dragOffY);
 }
 
-function endDrag(){
+function endDrag(e){
   svg.removeEventListener("pointermove", onDrag);
   svg.removeEventListener("pointerup", endDrag);
+  svg.removeEventListener("pointercancel", endDrag);
+  try{svg.releasePointerCapture(e.pointerId);}catch(_){}
   dragBead = null;
 }
 


### PR DESCRIPTION
## Summary
- allow touch interaction by disabling default touch actions on the SVG
- capture pointer events so beads drag smoothly
- show a grabbing cursor while dragging

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c3111d69008324bee27faf596723d7