### PR TITLE
Ensure 'kvadrat' creates a square in nkant parser

### DIFF
--- a/nkant.js
+++ b/nkant.js
@@ -184,7 +184,13 @@ function parseSpecFreeform(str){
     }
   });
 
-  if(/(kvadrat|firkant)/.test(text)){
+  if(/kvadrat/.test(text)){
+    const s = nums[0] ?? rand(1,5);
+    Object.assign(out, {a:s, b:s, c:s, d:s, B:90});
+    return out;
+  }
+
+  if(/firkant/.test(text)){
     if(nums.length >= 2){
       const w = nums[0];
       const h = nums[1];


### PR DESCRIPTION
## Summary
- Fix freeform parser so 'kvadrat' produces a square with equal sides and right angle
- Keep generic 'firkant' handling for rectangles/parallelograms

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c31265695c8324b52a9bd8f61fef7d