### PR TITLE
Scale bead and gap sizes via SIMPLE.beadRadius

### DIFF
--- a/perlesnor.js
+++ b/perlesnor.js
@@ -48,13 +48,16 @@ const ADV = {
 
 /* ============ DERIVERT KONFIG FOR RENDER (IKKE REDIGER) ============ */
 function makeCFG(){
+  const rBase = SIMPLE.beadRadius ?? ADV.rBase;
+  const scale = rBase / ADV.rBase;
+  const gapBase = ADV.gapBase * scale;
   return {
     nBeads: SIMPLE.nBeads,
     startIndex: clamp(SIMPLE.startIndex, 0, SIMPLE.nBeads),
     groupSize: ADV.groupSize,
 
-    rBase: ADV.rBase,
-    gapBase: ADV.gapBase,
+    rBase,
+    gapBase,
     wireY: ADV.wireY,
 
     kW: ADV.kW,


### PR DESCRIPTION
## Summary
- compute rBase from `SIMPLE.beadRadius` with default fallback
- scale gapBase using same factor for consistent spacing
- preserve use of `CFG.rBase`/`CFG.gapBase` in layout and draw

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c312fba7888324b43a1313fbb945e6