### PR TITLE
Add default triangular figures and reset option

### DIFF
--- a/figurtall.html
+++ b/figurtall.html
@@ -109,6 +109,7 @@
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="resetBtn" class="btn" type="button">Nullstill</button>
           </div>
         </div>
         <div class="card">
@@ -118,20 +119,20 @@
             <label>Rader
               <div class="stepper" aria-label="Antall ruter i høyden">
                 <button id="rowsMinus" type="button" aria-label="Færre rader">&minus;</button>
-                <span id="rowsVal">4</span>
+                <span id="rowsVal">3</span>
                 <button id="rowsPlus" type="button" aria-label="Flere rader">+</button>
               </div>
             </label>
             <label>Kolonner
               <div class="stepper" aria-label="Antall ruter i bredden">
                 <button id="colsMinus" type="button" aria-label="Færre kolonner">&minus;</button>
-                <span id="colsVal">4</span>
+                <span id="colsVal">3</span>
                 <button id="colsPlus" type="button" aria-label="Flere kolonner">+</button>
               </div>
             </label>
-            <label><input id="showGrid" type="checkbox" checked /> Vis rutenett</label>
-            <label><input id="offsetRows" type="checkbox" /> Forskyv annenhver rad</label>
-            <label><input id="circleMode" type="checkbox" /> Bruk sirkler</label>
+            <label><input id="showGrid" type="checkbox" /> Vis rutenett</label>
+            <label><input id="offsetRows" type="checkbox" checked /> Forskyv annenhver rad</label>
+            <label><input id="circleMode" type="checkbox" checked /> Bruk sirkler</label>
           </fieldset>
           <fieldset>
             <legend>Farger</legend>

--- a/figurtall.js
+++ b/figurtall.js
@@ -1,11 +1,11 @@
 (function(){
   const boxes=[];
-  // Default grid size set to 4x4
-  let rows=4;
-  let cols=4;
-  let circleMode=false;
-  let offset=false;
-  let showGrid=true;
+  // Default grid size set to 3x3 for triangular numbers
+  let rows=3;
+  let cols=3;
+  let circleMode=true;
+  let offset=true;
+  let showGrid=false;
 
   const colorCountInp=document.getElementById('colorCount');
   const colorInputs=[];
@@ -153,7 +153,7 @@
   const addBtn=document.getElementById('addFigure');
   let figureCount=0;
 
-  function addFigure(){
+  function addFigure(name='',pattern=[]){
     figureCount++;
     const panel=document.createElement('div');
     panel.className='figurePanel';
@@ -166,12 +166,19 @@
     boxes.push(box);
     createGrid(box);
     container.insertBefore(panel,addBtn);
+    if(name) panel.querySelector('.nameInput').value=name;
+    if(pattern && pattern.length){
+      pattern.forEach(([r,c])=>{
+        const row=box.querySelectorAll('.row')[r];
+        const cell=row?.querySelectorAll('.cell')[c];
+        if(cell) cell.dataset.color='1';
+      });
+    }
     updateCellColors();
+    return panel;
   }
 
-  for(let i=0;i<3;i++) addFigure();
-
-  addBtn.addEventListener('click',addFigure);
+  addBtn.addEventListener('click',()=>addFigure());
 
   const rowsMinus=document.getElementById('rowsMinus');
   const rowsPlus=document.getElementById('rowsPlus');
@@ -195,6 +202,7 @@
 
   const btnSvg=document.getElementById('btnSvg');
   const btnPng=document.getElementById('btnPng');
+  const resetBtn=document.getElementById('resetBtn');
 
   function svgToString(svgEl){
     const clone=svgEl.cloneNode(true);
@@ -326,7 +334,33 @@
     downloadPNG(svg,'figurtall.png',2);
   });
 
+  function resetAll(){
+    rows=3; cols=3;
+    rowsVal.textContent=rows;
+    colsVal.textContent=cols;
+    circleMode=true; offset=true; showGrid=false;
+    circleInp.checked=true;
+    offsetInp.checked=true;
+    gridInp.checked=false;
+    colorCount=1;
+    colorCountInp.value='1';
+    updateColorVisibility();
+
+    boxes.length=0;
+    container.querySelectorAll('.figurePanel').forEach(p=>p.remove());
+    figureCount=0;
+
+    addFigure('Figur 1',[[0,1]]);
+    addFigure('Figur 2',[[0,1],[1,0],[1,1]]);
+    addFigure('Figur 3',[[0,1],[1,0],[1,1],[2,0],[2,1],[2,2]]);
+
+    updateGridVisibility();
+  }
+
+  resetBtn?.addEventListener('click',resetAll);
+
   updateRows();
   updateCols();
+  resetAll();
 })();
 


### PR DESCRIPTION
## Summary
- preload triangular number figures and enable circle mode, offset rows, and hidden grid
- add reset button to restore default layout

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c31580d3e883248cb650e4797e1b49