### PR TITLE
Add SVG and PNG downloads for Kuler

### DIFF
--- a/kuler.html
+++ b/kuler.html
@@ -30,6 +30,8 @@
     .bead{cursor:grab;}
     .bead:active{cursor:grabbing;}
     .beadShadow{filter:drop-shadow(0 1px 1px rgba(0,0,0,.25));}
+    .downloadBtns{display:flex;gap:6px;flex-wrap:wrap;}
+    .downloadBtns button{border:1px solid #d1d5db;border-radius:6px;background:#fff;padding:6px 10px;cursor:pointer;}
   </style>
 </head>
 <body>
@@ -44,6 +46,10 @@
         <div class="card">
           <h2>Forfatters innstillinger</h2>
           <div id="controls"></div>
+          <div class="downloadBtns">
+            <button id="downloadSVG" type="button">Last ned SVG</button>
+            <button id="downloadPNG" type="button">Last ned PNG</button>
+          </div>
         </div>
       </div>
     </div>

--- a/kuler.js
+++ b/kuler.js
@@ -90,6 +90,9 @@ colors.forEach(color => {
 
 render();
 
+document.getElementById("downloadSVG").addEventListener("click", downloadSVG);
+document.getElementById("downloadPNG").addEventListener("click", downloadPNG);
+
 /* ============ FUNKSJONER ============ */
 function render(){
   gBowls.innerHTML = "";
@@ -196,3 +199,57 @@ function svgPoint(evt){
 function mk(n,attrs={}){ const e=document.createElementNS("http://www.w3.org/2000/svg",n);
   for(const [k,v] of Object.entries(attrs)) e.setAttribute(k,v); return e; }
 function cap(s){ return s[0].toUpperCase()+s.slice(1); }
+
+async function inlineImages(svgEl){
+  const imgs = svgEl.querySelectorAll("image");
+  await Promise.all(Array.from(imgs).map(async img => {
+    const src = img.getAttribute("href");
+    const res = await fetch(src);
+    const blob = await res.blob();
+    const dataUrl = await new Promise(res => {
+      const reader = new FileReader();
+      reader.onload = () => res(reader.result);
+      reader.readAsDataURL(blob);
+    });
+    img.setAttribute("href", dataUrl);
+  }));
+}
+
+async function downloadSVG(){
+  const clone = svg.cloneNode(true);
+  await inlineImages(clone);
+  const data = new XMLSerializer().serializeToString(clone);
+  const blob = new Blob([data], {type:"image/svg+xml"});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "kuler.svg";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+async function downloadPNG(){
+  const clone = svg.cloneNode(true);
+  await inlineImages(clone);
+  const data = new XMLSerializer().serializeToString(clone);
+  const svgBlob = new Blob([data], {type:"image/svg+xml"});
+  const url = URL.createObjectURL(svgBlob);
+  const img = new Image();
+  img.onload = () => {
+    const canvas = document.createElement("canvas");
+    canvas.width = VB_W;
+    canvas.height = VB_H;
+    const ctx = canvas.getContext("2d");
+    ctx.drawImage(img, 0, 0);
+    URL.revokeObjectURL(url);
+    canvas.toBlob(blob => {
+      const pngUrl = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = pngUrl;
+      a.download = "kuler.png";
+      a.click();
+      URL.revokeObjectURL(pngUrl);
+    });
+  };
+  img.src = url;
+}


### PR DESCRIPTION
## Summary
- allow users to export Kuler visualization as SVG or PNG
- add inline image handling for self-contained downloads

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c31777aadc8324a70ee4d67165e47f