### PR TITLE
Add coordinate point plotting and first-quadrant option

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -71,6 +71,11 @@
             <button id="addFunc" type="button" class="btn" aria-label="Legg til funksjon">+</button>
           </div>
           <div class="settings-row">
+            <label>Punktkoordinater
+              <input id="cfgCoords" type="text" value="" placeholder="x1,y1; x2,y2">
+            </label>
+          </div>
+          <div class="settings-row">
             <label>Screen (overstyrer autozoom hvis satt)
               <input id="cfgScreen" type="text" value="" placeholder="minX, maxX, minY, maxY">
             </label>
@@ -78,6 +83,7 @@
           <div class="settings-row">
             <label class="checkbox-label"><input id="cfgLock" type="checkbox"> Lås forhold 1:1 (krever screen)</label>
             <label class="checkbox-label"><input id="cfgPan" type="checkbox"> Tillat pan</label>
+            <label class="checkbox-label"><input id="cfgQ1" type="checkbox"> Bare 1. kvadrant</label>
           </div>
           <div class="settings-row axis-names">
             <label>Navn på akser</label>


### PR DESCRIPTION
## Summary
- allow entering fixed point coordinates to render on the graph
- add optional first-quadrant view toggle

## Testing
- `npm test` *(fails: no test specified)*
- `node --check graftegner.js`

------
https://chatgpt.com/codex/tasks/task_e_68c31d88e5208324ae63daf2df730fff