### PR TITLE
Improve axis name labels and input fields in Graftegner

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -38,7 +38,9 @@
     .settings-row label.checkbox-label{ flex:1 1 200px; }
     .checkbox-label{ flex-direction:row; align-items:center; gap:6px; white-space:normal; }
     .axis-names{ gap:12px; align-items:center; }
+    .axis-names label{ flex:0 0 auto; }
     .axis-label{ flex-direction:row; align-items:center; gap:4px; }
+    .axis-label input{ width:80px; }
   </style>
 </head>
 <body>

--- a/graftegner.js
+++ b/graftegner.js
@@ -497,19 +497,19 @@ const brd = JXG.JSXGraph.initBoard('board',{
 let xName=null,yName=null;
 function placeAxisNames(){
   const [xmin,ymax,xmax,ymin]=brd.getBoundingBox();
-  const rx=xmax-xmin, ry=ymax-ymin, off=0.02;
+  const rx=xmax-xmin, ry=ymax-ymin, off=0.04;
   if(!xName){
     xName = brd.create('text',[0,0,()=>ADV.axis.labels.x||'x'],
-      {anchorX:'right',anchorY:'bottom',fixed:true,fontSize:16, layer:40,
+      {anchorX:'right',anchorY:'top',fixed:true,fontSize:20, layer:40,
        color:ADV.axis.style.stroke, cssStyle:'pointer-events:none;user-select:none;'});
   }
   if(!yName){
     yName = brd.create('text',[0,0,()=>ADV.axis.labels.y||'y'],
-      {anchorX:'left',anchorY:'top',fixed:true,fontSize:16, layer:40,
+      {anchorX:'right',anchorY:'top',fixed:true,fontSize:20, layer:40,
        color:ADV.axis.style.stroke, cssStyle:'pointer-events:none;user-select:none;'});
   }
-  xName.moveTo([xmax-off*rx, 0+off*ry]);
-  yName.moveTo([0+off*rx, ymax-off*ry]);
+  xName.moveTo([xmax-off*rx, 0-off*ry]);
+  yName.moveTo([0-off*rx, ymax-off*ry]);
 }
 placeAxisNames();
 


### PR DESCRIPTION
## Summary
- enlarge and reposition axis labels on the graph for better readability
- fix layout of axis name settings fields and widen the inputs

## Testing
- `npm test` (fails: no test specified)

------
https://chatgpt.com/codex/tasks/task_e_68c31e3517f883248e7d8ed48cd6f68e