### PR TITLE
Set perlesnor default to 10 beads

### DIFF
--- a/perlesnor.js
+++ b/perlesnor.js
@@ -1,6 +1,6 @@
 /* ============ ENKEL KONFIG (FORFATTER) ============ */
 const SIMPLE = {
-  nBeads: 25,       // totalt antall perler
+  nBeads: 10,       // totalt antall perler
   startIndex: 2,    // startposisjon for klypa (antall til venstre)
 
   // Fasit (velg én form):


### PR DESCRIPTION
## Summary
- default perlesnor bead count is now 10

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c31ee71e1c832488a42f2d7ecd45b7