### PR TITLE
Align number figures by default

### DIFF
--- a/figurtall.html
+++ b/figurtall.html
@@ -133,7 +133,7 @@
               </div>
             </label>
             <label><input id="showGrid" type="checkbox" /> Vis rutenett</label>
-            <label><input id="offsetRows" type="checkbox" checked /> Forskyv annenhver rad</label>
+            <label><input id="offsetRows" type="checkbox" /> Forskyv annenhver rad</label>
             <label><input id="circleMode" type="checkbox" checked /> Bruk sirkler</label>
           </fieldset>
           <fieldset>

--- a/figurtall.js
+++ b/figurtall.js
@@ -1,10 +1,10 @@
 (function(){
   const boxes=[];
-  // Default grid size set to 3x3 for triangular numbers
+  // Default grid size set to 3x3 with aligned rows
   let rows=3;
   let cols=3;
   let circleMode=true;
-  let offset=true;
+  let offset=false;
   let showGrid=false;
 
   const colorCountInp=document.getElementById('colorCount');
@@ -338,9 +338,9 @@
     rows=3; cols=3;
     rowsVal.textContent=rows;
     colsVal.textContent=cols;
-    circleMode=true; offset=true; showGrid=false;
+    circleMode=true; offset=false; showGrid=false;
     circleInp.checked=true;
-    offsetInp.checked=true;
+    offsetInp.checked=false;
     gridInp.checked=false;
     colorCount=1;
     colorCountInp.value='1';


### PR DESCRIPTION
## Summary
- Start figurtall visualization without offset rows so dots align in columns
- Ensure reset restores non-offset layout and unchecks option

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c32f31869c8324a8018ea0b600b2dd