### PR TITLE
feat: clear figure colors on reset

### DIFF
--- a/figurtall.js
+++ b/figurtall.js
@@ -350,9 +350,10 @@
     container.querySelectorAll('.figurePanel').forEach(p=>p.remove());
     figureCount=0;
 
-    addFigure('Figur 1',[[0,1]]);
-    addFigure('Figur 2',[[0,1],[1,0],[1,1]]);
-    addFigure('Figur 3',[[0,1],[1,0],[1,1],[2,0],[2,1],[2,2]]);
+    // Recreate three blank figures so all color fields start empty
+    addFigure('Figur 1');
+    addFigure('Figur 2');
+    addFigure('Figur 3');
 
     updateGridVisibility();
   }


### PR DESCRIPTION
## Summary
- Ensure reset button recreates blank figures so all color cells are empty

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c32f9246b483249086ea36b8ad56ee