### PR TITLE
Add Kvikkbilder visualization for multiplication with bricks

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -1,0 +1,65 @@
+<!doctype html>
+<html lang="no">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Kvikkbilder</title>
+  <style>
+    :root { --gap: 18px; }
+    html,body{height:100%;}
+    body{
+      margin:0;
+      font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+      color:#111827;
+      background:#f7f8fb;
+      padding:20px;
+    }
+    .wrap{max-width:1200px;margin:0 auto;}
+    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    .side{display:flex;flex-direction:column;gap:var(--gap);}
+    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
+    .card{
+      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
+      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
+      display:flex;flex-direction:column;gap:10px;
+    }
+    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
+    #brickContainer{display:grid;gap:10px;justify-content:start;}
+    #brickContainer img{width:80px;height:auto;}
+    #expression{text-align:center;font-size:24px;font-weight:600;}
+    label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
+    input[type="number"]{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
+  </style>
+</head>
+<body>
+  <div class="wrap">
+    <div class="grid">
+      <div class="card">
+        <div id="brickContainer" class="figure" aria-label="Kvikkbilder"></div>
+        <div id="expression"></div>
+      </div>
+      <div class="side">
+        <div class="card">
+          <h2>Forfatters innstillinger</h2>
+          <label>Antall X
+            <input id="cfg-antallX" type="number" min="1" value="5">
+          </label>
+          <label>Antall Y
+            <input id="cfg-antallY" type="number" min="1" value="2">
+          </label>
+          <label>Bredde
+            <input id="cfg-bredde" type="number" min="1" value="2">
+          </label>
+          <label>Høyde
+            <input id="cfg-hoyde" type="number" min="1" value="3">
+          </label>
+          <label>Dybde
+            <input id="cfg-dybde" type="number" min="1" value="3">
+          </label>
+        </div>
+      </div>
+    </div>
+  </div>
+  <script src="kvikkbilder.js"></script>
+</body>
+</html>

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -1,0 +1,35 @@
+(function(){
+  const cfgAntallX = document.getElementById('cfg-antallX');
+  const cfgAntallY = document.getElementById('cfg-antallY');
+  const cfgBredde = document.getElementById('cfg-bredde');
+  const cfgHoyde = document.getElementById('cfg-hoyde');
+  const cfgDybde = document.getElementById('cfg-dybde');
+  const brickContainer = document.getElementById('brickContainer');
+  const expression = document.getElementById('expression');
+
+  function render(){
+    const antallX = parseInt(cfgAntallX.value,10) || 0;
+    const antallY = parseInt(cfgAntallY.value,10) || 0;
+    const bredde = parseInt(cfgBredde.value,10) || 0;
+    const hoyde = parseInt(cfgHoyde.value,10) || 0;
+    const dybde = parseInt(cfgDybde.value,10) || 0;
+
+    brickContainer.innerHTML = '';
+    brickContainer.style.gridTemplateColumns = `repeat(${antallX}, auto)`;
+    for(let i = 0; i < antallX * antallY; i++){
+      const img = document.createElement('img');
+      img.src = 'images/brick1.svg';
+      img.alt = `${bredde}x${hoyde}x${dybde} kloss`;
+      brickContainer.appendChild(img);
+    }
+
+    const total = antallX * antallY * bredde * hoyde * dybde;
+    expression.textContent = `${antallX} × ${antallY} × ${bredde} × ${hoyde} × ${dybde} = ${total}`;
+  }
+
+  [cfgAntallX, cfgAntallY, cfgBredde, cfgHoyde, cfgDybde].forEach(el =>{
+    el.addEventListener('input', render);
+  });
+
+  render();
+})();


### PR DESCRIPTION
## Summary
- Introduce Kvikkbilder HTML page and script
- Render Lego brick grids configurable by X/Y count and brick dimensions

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c33042b4488324a17b45fcb7e8730c