### PR TITLE
Hide point selector for parametric lines

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -1117,7 +1117,7 @@ function setupSettingsForm(){
     const fun = paramStr(key, i === 1 ? 'f(x)=x^2-2' : '');
     const dom = paramStr(`dom${i}`, '');
     if(i === 1 || params.has(key)){
-      createRow(i, fun, dom, i === 1);
+      createRow(i, fun, dom, i === 1 && MODE === 'functions');
       i++;
     } else {
       break;


### PR DESCRIPTION
## Summary
- hide author 'Punkter' dropdown when the first function is symbolic (e.g., f(x)=ax+b)

## Testing
- `npm test` (fails: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c4323b1ce4832485b9186c099e3b32