### PR TITLE
Highlight 2×2×3 composition in Kvikkbilder

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -55,7 +55,7 @@
             <input id="cfg-hoyde" type="number" min="1" value="3">
           </label>
           <label>Dybde
-            <input id="cfg-dybde" type="number" min="1" value="3">
+            <input id="cfg-dybde" type="number" min="1" value="2">
           </label>
         </div>
       </div>

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -156,8 +156,9 @@
       brickContainer.appendChild(fig);
     }
 
-    const total = antallX * antallY * bredde * hoyde * dybde;
-    expression.textContent = `${antallX} × ${antallY} × ${bredde} × ${hoyde} × ${dybde} = ${total}`;
+    const perFig = bredde * hoyde * dybde;
+    const total = antallX * antallY * perFig;
+    expression.textContent = `${antallX} × ${antallY} × (${bredde} × ${hoyde} × ${dybde}) = ${antallX * antallY} × ${perFig} = ${total}`;
   }
 
   [cfgAntallX, cfgAntallY, cfgBredde, cfgHoyde, cfgDybde].forEach(el =>{


### PR DESCRIPTION
## Summary
- Group brick dimensions in displayed expression to show each figure as 2×2×3 bricks
- Default depth set to 2 to match 2×2×3 configuration

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c488104868832484a7bf30e32fc250