### PR TITLE
Show figure 2 settings only with two figures

### DIFF
--- a/nkant.html
+++ b/nkant.html
@@ -77,7 +77,7 @@ Rettvinklet trekant</textarea>
 
         <!-- Figur 1 -->
         <div class="legend">Figur 1</div>
-        <div class="form-row">
+          <div class="form-row">
           <div>
             <label>Standard sider</label>
             <select id="f1Sides">
@@ -100,7 +100,7 @@ Rettvinklet trekant</textarea>
           </div>
         </div>
 
-        <div class="form-row">
+          <div class="form-row">
           <div>
             <div class="legend">Enkeltside</div>
             <div class="grid-3">
@@ -177,10 +177,11 @@ Rettvinklet trekant</textarea>
           </div>
         </div>
 
-        <div class="sep"></div>
+        <div id="fig2Settings">
+          <div class="sep"></div>
 
-        <!-- Figur 2 -->
-        <div class="legend">Figur 2</div>
+          <!-- Figur 2 -->
+          <div class="legend">Figur 2</div>
         <div class="form-row">
           <div>
             <label>Standard sider</label>
@@ -279,6 +280,7 @@ Rettvinklet trekant</textarea>
               <input id="f2AngDTxt" class="tight" type="text" placeholder="D" />
             </div>
           </div>
+        </div>
         </div>
 
         <div class="sep"></div>

--- a/nkant.js
+++ b/nkant.js
@@ -742,6 +742,9 @@ async function renderCombined(){
   const jobs = await collectJobsFromSpecs(STATE.specsText);
   const n = jobs.length;
 
+  const fig2Settings = document.getElementById("fig2Settings");
+  if(fig2Settings) fig2Settings.style.display = n >= 2 ? "" : "none";
+
   if(n===0){
     svg.setAttribute("viewBox", `0 0 ${BASE_W} ${BASE_H}`);
     add(svg,"text",{x:20,y:40,fill:"#6b7280","font-size":18}).textContent = "Skriv 1–2 SPECS- eller tekstlinjer for å tegne figur(er).";


### PR DESCRIPTION
## Summary
- Wrap figure 2 controls in a dedicated container
- Hide figure 2 settings unless two figures are parsed from free text

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c724711b0c8324860bc6dcbb456894