### PR TITLE
Add plus button for second data series

### DIFF
--- a/diagram/index.html
+++ b/diagram/index.html
@@ -78,7 +78,7 @@
             </label>
           </div>
           <div class="settings-row">
-            <button id="addSeries" class="btn" type="button">Legg til serie</button>
+            <button id="addSeries" class="btn" type="button" aria-label="Legg til dataserie">+</button>
           </div>
           <div id="series2Fields" style="display:none">
             <div class="settings-row">


### PR DESCRIPTION
## Summary
- show `+` button for adding a second data series in the diagram tool

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c724c11f788324924e2fc9f3bd3bc8