### PR TITLE
Add SVG/PNG downloads for Kvikkbilder

### DIFF
--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -30,6 +30,10 @@
     label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
     input[type="number"]{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
     #playBtn{align-self:center;padding:20px 30px;font-size:20px;cursor:pointer;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
+    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
+    .btn:active{transform:translateY(1px);}
   </style>
   <link rel="stylesheet" href="split.css" />
 </head>
@@ -42,6 +46,13 @@
         <div id="expression"></div>
       </div>
       <div class="side">
+        <div class="card">
+          <h2>Last ned figurer</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
         <div class="card">
           <h2>Forfatters innstillinger</h2>
             <label>Vis play-knapp

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -53,6 +53,10 @@
       justify-content:center;
       box-shadow:0 2px 8px rgba(0,0,0,.15);
     }
+    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
+    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
+    .btn:active{transform:translateY(1px);}
   </style>
   <link rel="stylesheet" href="split.css" />
 </head>
@@ -66,6 +70,13 @@
         <div id="expression"></div>
       </div>
       <div class="side">
+        <div class="card">
+          <h2>Last ned figurer</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
         <div class="card">
           <h2>Forfatters innstillinger</h2>
           <label>Type

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -19,6 +19,8 @@
   const patternContainer = document.getElementById('patternContainer');
   const playBtn = document.getElementById('playBtn');
   const expression = document.getElementById('expression');
+  const btnSvg = document.getElementById('btnSvg');
+  const btnPng = document.getElementById('btnPng');
 
   const BRICK_SRC = 'images/brick1.svg';
 
@@ -247,6 +249,64 @@
       }, duration*1000);
     }
   });
+
+  btnSvg?.addEventListener('click', ()=>{
+    const svg = brickContainer.querySelector('svg') || patternContainer.querySelector('svg');
+    if(svg) downloadSVG(svg, 'kvikkbilder.svg');
+  });
+  btnPng?.addEventListener('click', ()=>{
+    const svg = brickContainer.querySelector('svg') || patternContainer.querySelector('svg');
+    if(svg) downloadPNG(svg, 'kvikkbilder.png', 2);
+  });
+
+  function svgToString(svgEl){
+    const clone = svgEl.cloneNode(true);
+    const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
+    const style = document.createElement('style');
+    style.textContent = css;
+    clone.insertBefore(style, clone.firstChild);
+    clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
+    clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
+  }
+  function downloadSVG(svgEl, filename){
+    const data = svgToString(svgEl);
+    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename.endsWith('.svg') ? filename : filename + '.svg';
+    document.body.appendChild(a); a.click(); a.remove();
+    setTimeout(()=>URL.revokeObjectURL(url),1000);
+  }
+  function downloadPNG(svgEl, filename, scale=2, bg='#fff'){
+    const vb = svgEl.viewBox?.baseVal;
+    const w = vb?.width || svgEl.clientWidth || 420;
+    const h = vb?.height|| svgEl.clientHeight || 420;
+    const data = svgToString(svgEl);
+    const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+    const url  = URL.createObjectURL(blob);
+    const img = new Image();
+    img.onload = ()=>{
+      const canvas = document.createElement('canvas');
+      canvas.width  = Math.round(w * scale);
+      canvas.height = Math.round(h * scale);
+      const ctx = canvas.getContext('2d');
+      ctx.fillStyle = bg;
+      ctx.fillRect(0,0,canvas.width,canvas.height);
+      ctx.drawImage(img,0,0,canvas.width,canvas.height);
+      URL.revokeObjectURL(url);
+      canvas.toBlob(blob=>{
+        const urlPng = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = urlPng;
+        a.download = filename.endsWith('.png') ? filename : filename + '.png';
+        document.body.appendChild(a); a.click(); a.remove();
+        setTimeout(()=>URL.revokeObjectURL(urlPng),1000);
+      },'image/png');
+    };
+    img.src = url;
+  }
 
   renderKlosser();
   renderMonster();


### PR DESCRIPTION
## Summary
- add toolbar with SVG/PNG download buttons to Kvikkbilder and Kvikkbilder-monster pages
- implement export helpers for generating SVG and PNG files from current figure

## Testing
- `node --check kvikkbilder.js`
- `node --check kvikkbilder-monster.js`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7b717321c83248d1b8cff23bd5332