### PR TITLE
Restore plus-minus stepper for Tenkeblokker

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -67,6 +67,18 @@
     .tb-right{top:50%;left:100%;transform:translate(10px,-50%);}
     .tb-bottom{top:100%;left:50%;transform:translate(-50%,10px);}
 
+    .tb-stepper{display:flex;gap:10px;justify-content:center;margin-top:10px}
+    .tb-stepper button{
+      width:40px;height:40px;
+      border:1px solid #cfcfcf;
+      border-radius:10px;
+      background:#fff;
+      font-size:24px;
+      cursor:pointer;
+      box-shadow:0 2px 8px rgba(0,0,0,.06);
+    }
+    .tb-stepper button:active{transform:translateY(1px)}
+
     .tb-toolbar{display:flex;gap:10px;justify-content:flex-end}
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
@@ -85,6 +97,10 @@
           <button id="tbAddCol" class="tb-add-btn tb-right" type="button" aria-label="Legg til kolonne">+</button>
           <button id="tbAddRow" class="tb-add-btn tb-bottom" type="button" aria-label="Legg til rad">+</button>
           <div id="tbLive" aria-live="polite" style="position:absolute;left:-9999px;width:1px;height:1px;overflow:hidden;"></div>
+        </div>
+        <div id="tbStepper" class="tb-stepper">
+          <button id="tbMinus" type="button" aria-label="Fyll færre blokker">−</button>
+          <button id="tbPlus" type="button" aria-label="Fyll flere blokker">+</button>
         </div>
       </div>
 

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -82,12 +82,17 @@ const addColBtn    = document.getElementById('tbAddCol');
 const addRowBtn    = document.getElementById('tbAddRow');
 const btnSvg       = document.getElementById('btnSvg');
 const btnPng       = document.getElementById('btnPng');
+const minusBtn     = document.getElementById('tbMinus');
+const plusBtn      = document.getElementById('tbPlus');
+const stepper      = document.getElementById('tbStepper');
 
 // ---------- Interaksjon ----------
 addColBtn?.addEventListener('click', ()=> setN(n+1));
 addRowBtn?.addEventListener('click', ()=> setM(m+1));
 btnSvg?.addEventListener('click', ()=> downloadSVG(svg, 'tenkeblokker.svg'));
 btnPng?.addEventListener('click', ()=> downloadPNG(svg, 'tenkeblokker.png', 2));
+minusBtn?.addEventListener('click', ()=> setK(k-1));
+plusBtn?.addEventListener('click', ()=> setK(k+1));
 
 handle.addEventListener('pointerdown', onDragStart);
 overlay?.addEventListener('keydown', e=>{
@@ -285,6 +290,7 @@ function applyConfig(){
   }
   if(addColBtn) addColBtn.style.display = CFG.showStepper ? '' : 'none';
   if(addRowBtn) addRowBtn.style.display = CFG.showStepper ? '' : 'none';
+  if(stepper) stepper.style.display = CFG.showStepper ? '' : 'none';
   gHandle.style.display  = CFG.showHandle ? '' : 'none';
   redraw();
 }
@@ -361,6 +367,7 @@ function redraw(){
   handleShadow.setAttribute('cy', hy+2);
   updateAria();
   updateAddButtons();
+  updateStepperButtons();
 }
 
 function updateAria(){
@@ -378,6 +385,15 @@ function updateAddButtons(){
   }
   if(addRowBtn){
     addRowBtn.style.visibility = m < CFG.maxM ? 'visible' : 'hidden';
+  }
+}
+
+function updateStepperButtons(){
+  if(minusBtn){
+    minusBtn.disabled = k <= 0;
+  }
+  if(plusBtn){
+    plusBtn.disabled = k >= n*m;
   }
 }
 


### PR DESCRIPTION
## Summary
- add plus/minus stepper UI under Tenkeblokker figure
- hook stepper into existing logic to increment or decrement filled blocks
- display stepper based on `showStepper` setting

## Testing
- `npm test` *(fails: "Error: no test specified")*


------
https://chatgpt.com/codex/tasks/task_e_68c7b819dc408324b78936b4d7d001d1