### PR TITLE
Add menu for loading saved examples

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -15,6 +15,19 @@
     const svg = document.querySelector('svg');
     return {config: cfg, svg: svg ? svg.outerHTML : ''};
   }
+
+  function loadExample(index){
+    const examples = getExamples();
+    const ex = examples[index];
+    if(!ex || !ex.config) return;
+    const cfg = ex.config;
+    if(cfg.STATE && window.STATE) Object.assign(window.STATE, cfg.STATE);
+    if(cfg.CFG && window.CFG) Object.assign(window.CFG, cfg.CFG);
+    if(cfg.CONFIG && window.CONFIG) Object.assign(window.CONFIG, cfg.CONFIG);
+    if(typeof window.render === 'function') window.render();
+    if(typeof window.draw === 'function') window.draw();
+    if(typeof window.update === 'function') window.update();
+  }
   // Load example if viewer requested
   (function(){
     const loadInfo = localStorage.getItem('example_to_load');
@@ -42,10 +55,31 @@
   const deleteBtn = document.getElementById('btnDeleteExample');
   if(!saveBtn && !deleteBtn) return;
 
+  const toolbar = saveBtn?.parentElement;
+  const select = document.createElement('select');
+  select.id = 'exampleSelect';
+  select.addEventListener('change', ()=>{
+    const idx = Number(select.value);
+    if(!Number.isNaN(idx)) loadExample(idx);
+  });
+  toolbar?.appendChild(select);
+
+  function renderOptions(){
+    const examples = getExamples();
+    select.innerHTML = '';
+    examples.forEach((_, idx)=>{
+      const opt = document.createElement('option');
+      opt.value = idx;
+      opt.textContent = idx + 1;
+      select.appendChild(opt);
+    });
+  }
+
   saveBtn?.addEventListener('click', ()=>{
     const examples = getExamples();
     examples.push(collectConfig());
     store(examples);
+    renderOptions();
     alert('Eksempel lagret');
   });
   deleteBtn?.addEventListener('click', ()=>{
@@ -53,7 +87,10 @@
     if(examples.length>0){
       examples.pop();
       store(examples);
+      renderOptions();
       alert('Siste eksempel slettet');
     }
   });
+
+  renderOptions();
 })();


### PR DESCRIPTION
## Summary
- Add loadExample helper and dropdown menu listing saved examples
- Update save/delete logic to refresh list and allow quick loading

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7cf038244832482baf220c8b0809b