### PR TITLE
Legg til innstillinger for Tenkeblokker

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -1,35 +1,98 @@
+<!doctype html>
+<html lang="no">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <title>Tenkeblokker</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
-
-<div class="tb-wrap">
-  <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker"></svg>
-
-  <div class="tb-stepper" aria-label="Antall blokker">
-    <button id="tbMinus" type="button" aria-label="Færre blokker">−</button>
-    <div class="tb-divider"></div>
-    <button id="tbPlus"  type="button" aria-label="Flere blokker">+</button>
+  <style>
+    :root { --gap:18px; }
+    html,body{height:100%;}
+    body{
+      margin:0; font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif;
+      color:#111827; background:#f7f8fb; padding:20px;
+    }
+    .wrap{max-width:1200px;margin:0 auto;}
+    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    .side{display:flex;flex-direction:column;gap:var(--gap);}
+    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
+    .card{
+      background:#fff;border:1px solid #e5e7eb;border-radius:14px;
+      box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
+      display:flex;flex-direction:column;gap:10px;
+    }
+    .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
+    .figure{border-radius:10px;background:#fff;overflow:hidden;border:1px solid #eef0f3;}
+    .figure svg{width:100%;height:auto;display:block;}
+    .toolbar{display:flex;gap:10px;justify-content:flex-end;}
+    .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
+    .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
+    .btn:active{transform:translateY(1px);}
+    label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
+    input[type="number"]{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
+    /* Tenkeblokker spesifikt */
+    .tb-stepper{display:flex;align-items:center;gap:0;border:1px solid #cfcfcf;border-radius:16px;padding:6px;background:#fff;box-shadow:0 6px 24px rgba(0,0,0,.08);align-self:center;}
+    .tb-stepper button{width:64px;height:48px;border:0;background:#fff;font-size:28px;cursor:pointer;}
+    .tb-stepper button:active{transform:translateY(1px);}
+    .tb-divider{width:1px;height:36px;background:#d6d6e3;margin:0 6px;}
+    .tb-rect{fill:#e8eedf}
+    .tb-rect-empty{fill:#ffffff}
+    .tb-frame{fill:none;stroke:#333;stroke-width:6}
+    .tb-sep{stroke:#555;stroke-width:2;stroke-dasharray:8 8;opacity:.6}
+    .tb-brace{fill:none;stroke:#0e6577;stroke-width:6;stroke-linecap:round}
+    .tb-total{font-size:34px;fill:#000;text-anchor:middle}
+    .tb-val{font-size:34px;fill:#111;text-anchor:middle;dominant-baseline:middle}
+    .tb-handle-shadow{fill:#000;opacity:.12}
+    .tb-handle{fill:#f1f1f6;stroke:#555;stroke-width:2;cursor:pointer}
+  </style>
+  <link rel="stylesheet" href="split.css" />
+</head>
+<body>
+  <div class="wrap">
+    <div class="grid">
+      <div class="card">
+        <div class="figure">
+          <svg id="thinkBlocks" viewBox="0 0 900 420" aria-label="Tenkeblokker"></svg>
+        </div>
+        <div class="tb-stepper" aria-label="Antall blokker">
+          <button id="tbMinus" type="button" aria-label="Færre blokker">−</button>
+          <div class="tb-divider"></div>
+          <button id="tbPlus"  type="button" aria-label="Flere blokker">+</button>
+        </div>
+      </div>
+      <div class="side">
+        <div class="card">
+          <h2>Last ned figurer</h2>
+          <div class="toolbar">
+            <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
+            <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+            <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
+            <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
+          </div>
+        </div>
+        <div class="card">
+          <h2>Forfatters innstillinger</h2>
+          <label>Totaltall
+            <input id="cfg-total" type="number" min="1" value="50">
+          </label>
+          <label>Min n
+            <input id="cfg-min-n" type="number" min="1" value="2">
+          </label>
+          <label>Maks n
+            <input id="cfg-max-n" type="number" min="1" value="12">
+          </label>
+          <label>Antall blokker (n)
+            <input id="cfg-n" type="number" min="1" value="5">
+          </label>
+          <label>Fylte blokker (k)
+            <input id="cfg-k" type="number" min="0" value="4">
+          </label>
+        </div>
+      </div>
+    </div>
   </div>
-</div>
-
-<style>
-  .tb-wrap{display:grid;place-items:center;gap:16px;padding:20px;font-family:system-ui,-apple-system,Segoe UI,Roboto,Arial,sans-serif}
-  /* SVG */
-  #thinkBlocks{width:min(900px,92vw);height:auto;background:#fff}
-  .tb-rect{fill:#e8eedf}
-  .tb-rect-empty{fill:#ffffff}
-  .tb-frame{fill:none;stroke:#333;stroke-width:6}
-  .tb-sep{stroke:#555;stroke-width:2;stroke-dasharray:8 8;opacity:.6}
-  .tb-brace{fill:none;stroke:#0e6577;stroke-width:6;stroke-linecap:round}
-  .tb-total{font-size:34px;fill:#000;text-anchor:middle}
-  .tb-val{font-size:34px;fill:#111;text-anchor:middle;dominant-baseline:middle}
-  .tb-handle-shadow{fill:#000;opacity:.12}
-  .tb-handle{fill:#f1f1f6;stroke:#555;stroke-width:2;cursor:pointer}
-
-  /* Stepper */
-  .tb-stepper{display:flex;align-items:center;gap:0;border:1px solid #cfcfcf;border-radius:16px;
-              padding:6px;background:#fff;box-shadow:0 6px 24px rgba(0,0,0,.08)}
-  .tb-stepper button{width:64px;height:48px;border:0;background:#fff;font-size:28px;cursor:pointer}
-  .tb-stepper button:active{transform:translateY(1px)}
-  .tb-divider{width:1px;height:36px;background:#d6d6e3;margin:0 6px}
-</style>
-
-<script src="tenkeblokker.js"></script>
+  <script src="tenkeblokker.js"></script>
+  <script src="examples.js"></script>
+  <script src="split.js"></script>
+</body>
+</html>

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -1,12 +1,19 @@
 /* Tenkeblokker – full JS m/ firkantparentes */
 
 // ---------- Konfig ----------
-const TOTAL = 50;          // tallet i parentesen
-const MIN_N = 2;
-const MAX_N = 12;
-
-let n = 5;                 // antall blokker (nevner)
-let k = 4;                 // antall fylte blokker (teller), 0..n
+const CONFIG = {
+  total: 50,
+  minN: 2,
+  maxN: 12,
+  n: 5,
+  k: 4
+};
+window.CONFIG = CONFIG;
+let TOTAL = CONFIG.total;          // tallet i parentesen
+let MIN_N = CONFIG.minN;
+let MAX_N = CONFIG.maxN;
+let n = CONFIG.n;                 // antall blokker (nevner)
+let k = CONFIG.k;                 // antall fylte blokker (teller), 0..n
 
 // Parentes-utseende
 const BRACKET_TICK   = 16; // lengde på «haken» ned i hver ende
@@ -36,7 +43,8 @@ addTo(gFrame,'rect',{x:L,y:TOP,width:R-L,height:BOT-TOP,class:'tb-frame'});
 
 // Firkantparentes + total
 drawBracketSquare(L, R, BRACE_Y, BRACKET_TICK);
-addTo(gBrace,'text',{x:(L+R)/2, y:BRACE_Y - LABEL_OFFSET_Y, class:'tb-total'}).textContent = TOTAL;
+const totalText = addTo(gBrace,'text',{x:(L+R)/2, y:BRACE_Y - LABEL_OFFSET_Y, class:'tb-total'});
+totalText.textContent = TOTAL;
 
 // Håndtak
 const handleShadow = addTo(gHandle,'circle',{cx:R, cy:(TOP+BOT)/2+2, r:20, class:'tb-handle-shadow'});
@@ -136,13 +144,130 @@ function redraw(){
 // ---------- State ----------
 function setN(next){
   n = clamp(next, MIN_N, MAX_N);
+  CONFIG.n = n;
+  cfgN.value = n;
+  cfgK.max = n;
   if(k>n) k = n;
+  cfgK.value = k;
+  CONFIG.k = k;
   redraw();
 }
 function setK(next){
   k = clamp(next, 0, n);
+  CONFIG.k = k;
+  cfgK.value = k;
   redraw();
 }
 
+// ---------- Eksport & kontroller ----------
+const cfgTotal = document.getElementById('cfg-total');
+const cfgMinN  = document.getElementById('cfg-min-n');
+const cfgMaxN  = document.getElementById('cfg-max-n');
+const cfgN     = document.getElementById('cfg-n');
+const cfgK     = document.getElementById('cfg-k');
+
+cfgTotal.addEventListener('input', ()=>{
+  TOTAL = CONFIG.total = parseInt(cfgTotal.value,10) || 0;
+  totalText.textContent = TOTAL;
+  redraw();
+});
+cfgMinN.addEventListener('input', ()=>{
+  MIN_N = CONFIG.minN = parseInt(cfgMinN.value,10) || 1;
+  setN(n);
+});
+cfgMaxN.addEventListener('input', ()=>{
+  MAX_N = CONFIG.maxN = parseInt(cfgMaxN.value,10) || 1;
+  setN(n);
+});
+cfgN.addEventListener('input', ()=> setN(parseInt(cfgN.value,10) || n));
+cfgK.addEventListener('input', ()=> setK(parseInt(cfgK.value,10) || k));
+
+function render(){
+  TOTAL = CONFIG.total;
+  MIN_N = CONFIG.minN;
+  MAX_N = CONFIG.maxN;
+  n = clamp(CONFIG.n, MIN_N, MAX_N);
+  k = clamp(CONFIG.k, 0, n);
+  CONFIG.n = n;
+  CONFIG.k = k;
+  cfgTotal.value = TOTAL;
+  cfgMinN.value = MIN_N;
+  cfgMaxN.value = MAX_N;
+  cfgN.value = n;
+  cfgK.max = n;
+  cfgK.value = k;
+  totalText.textContent = TOTAL;
+  redraw();
+}
+
+document.getElementById('btnSvg').addEventListener('click', ()=> downloadSVG(svg, 'tenkeblokker.svg'));
+document.getElementById('btnPng').addEventListener('click', ()=> downloadPNG(svg, 'tenkeblokker.png', 2));
+
+// ---------- SVG til fil ----------
+function svgToString(svgEl){
+  const clone = svgEl.cloneNode(true);
+  const css = [...document.querySelectorAll('style')].map(s => s.textContent).join('\n');
+  const style = document.createElement('style');
+  style.textContent = css;
+  clone.insertBefore(style, clone.firstChild);
+
+  const ids = new Set();
+  clone.querySelectorAll('[aria-describedby]').forEach(el => {
+    el.getAttribute('aria-describedby')?.split(/\s+/).forEach(id => ids.add(id));
+  });
+  ids.forEach(id => {
+    if(!id || clone.getElementById(id)) return;
+    const src = document.getElementById(id);
+    if(src){
+      const desc = document.createElementNS('http://www.w3.org/2000/svg','desc');
+      desc.setAttribute('id', id);
+      desc.textContent = src.textContent;
+      clone.insertBefore(desc, style.nextSibling);
+    }
+  });
+
+  clone.setAttribute('xmlns','http://www.w3.org/2000/svg');
+  clone.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink');
+  return '<?xml version="1.0" encoding="UTF-8"?>\n' + new XMLSerializer().serializeToString(clone);
+}
+function downloadSVG(svgEl, filename){
+  const data = svgToString(svgEl);
+  const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename.endsWith('.svg') ? filename : filename + '.svg';
+  document.body.appendChild(a); a.click(); a.remove();
+  setTimeout(()=>URL.revokeObjectURL(url),1000);
+}
+function downloadPNG(svgEl, filename, scale=2, bg='#fff'){
+  const vb = svgEl.viewBox.baseVal;
+  const w = vb?.width  || svgEl.clientWidth  || VBW;
+  const h = vb?.height || svgEl.clientHeight || VBH;
+  const data = svgToString(svgEl);
+  const blob = new Blob([data], {type:'image/svg+xml;charset=utf-8'});
+  const url  = URL.createObjectURL(blob);
+  const img = new Image();
+  img.onload = ()=>{
+    const canvas = document.createElement('canvas');
+    canvas.width  = Math.round(w * scale);
+    canvas.height = Math.round(h * scale);
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = bg;
+    ctx.fillRect(0,0,canvas.width,canvas.height);
+    ctx.drawImage(img,0,0,canvas.width,canvas.height);
+    URL.revokeObjectURL(url);
+    canvas.toBlob(blob=>{
+      const urlPng = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = urlPng;
+      a.download = filename.endsWith('.png') ? filename : filename + '.png';
+      document.body.appendChild(a); a.click(); a.remove();
+      setTimeout(()=>URL.revokeObjectURL(urlPng),1000);
+    }, 'image/png');
+  };
+  img.src = url;
+}
+
 // init
-redraw();
+render();


### PR DESCRIPTION
## Summary
- Legg til fullstendig HTML-side for Tenkeblokker med nedlastingsknapper og forfatterinnstillinger
- Gjør Tenkeblokker-konfigurerbar via inputfelter og legg til eksport som SVG/PNG
- Synkroniser CONFIG med gjeldende visning via en global `render`-funksjon slik at lagrede eksempler lastes korrekt

## Testing
- `npm test` *(forventet feil: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c800dae5308324be9371c7dada8b7d