### PR TITLE
Align tenkeblokker panels without gap

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -31,8 +31,15 @@
       padding:12px 4px 4px;
       flex-wrap:nowrap;
       overflow-x:auto;
+      --tb-svg-width:min(420px,88vw);
+      --tb-overlap:calc(var(--tb-svg-width) * 140 / 900);
     }
-    .tb-panels.two{gap:0;justify-content:flex-start;}
+    .tb-panels.two{
+      gap:0;
+      justify-content:flex-start;
+      --tb-svg-width:min(420px,44vw);
+    }
+    .tb-panels.two .tb-panel + .tb-panel{margin-left:calc(-1 * var(--tb-overlap));}
     .tb-panels > *{flex:0 0 auto;}
     .tb-panel{display:flex;flex-direction:column;align-items:center;gap:16px;max-width:420px;}
     .tb-svg{width:min(420px,88vw);height:auto;background:#fff;}

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -45,7 +45,8 @@ CONFIG.showPercent = CONFIG.blocks[0].showPercent;
 
 // ---------- SVG-oppsett ----------
 const VBW = 900, VBH = 420;                  // MÅ samsvare med viewBox i HTML
-const L = 70, R = VBW - 70;                  // venstre/høyre marg
+const SIDE_MARGIN = 70;                      // tomrom på hver side av rammen
+const L = SIDE_MARGIN, R = VBW - SIDE_MARGIN; // venstre/høyre marg
 const TOP = 130, BOT = VBH - 60;             // ramme-topp/-bunn
 const BRACE_Y = 78;                          // høyde for parentes
 const BRACKET_TICK = 16;                     // lengde på «haken» ned i hver ende
@@ -176,8 +177,9 @@ function getExportSvg() {
   if (count === 1) return firstSvg;
 
   const ns = firstSvg.namespaceURI;
-  const gap = 0;
-  const width = count * VBW + (count - 1) * gap;
+  const overlap = count > 1 ? SIDE_MARGIN * 2 : 0;
+  const step = VBW - overlap;
+  const width = count > 0 ? VBW + (count - 1) * step : 0;
   const exportSvg = document.createElementNS(ns, 'svg');
   exportSvg.setAttribute('viewBox', `0 0 ${width} ${VBH}`);
   exportSvg.setAttribute('width', width);
@@ -193,8 +195,7 @@ function getExportSvg() {
     g.setAttribute('transform', `translate(${x},0)`);
     g.innerHTML = block.svg.innerHTML;
     exportSvg.appendChild(g);
-    x += VBW;
-    if (i < count - 1) x += gap;
+    if (i < count - 1) x += step;
   }
   return exportSvg;
 }


### PR DESCRIPTION
## Summary
- adjust the tenkeblokker panel layout so the second figure overlaps the SVG side margins when both blocks are shown, making the frames touch
- update SVG export assembly to reuse the same overlap so combined downloads place the two blocks directly next to each other

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68c86bdca2788324b23d7d4b56d94fd9