### PR TITLE
Improve kvikkbilder layout and pattern rendering

### DIFF
--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -24,12 +24,42 @@
       display:flex;flex-direction:column;gap:10px;
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
-    #patternContainer{display:grid;gap:10px;justify-content:center;}
-    #patternContainer svg{height:auto;}
+    .figure-area{
+      position:relative;
+      width:min(80vmin,100%);
+      aspect-ratio:1;
+      align-self:center;
+      margin:0 auto;
+    }
+    #patternContainer{
+      position:absolute;
+      inset:0;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    #patternContainer svg{width:100%;height:100%;display:block;}
     #expression{text-align:center;font-size:24px;font-weight:600;}
     label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
     input[type="number"]{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
-    #playBtn{align-self:center;padding:20px 30px;font-size:20px;cursor:pointer;}
+    #playBtn{
+      position:absolute;
+      top:50%;
+      left:50%;
+      transform:translate(-50%,-50%);
+      width:160px;
+      height:160px;
+      border-radius:50%;
+      border:none;
+      background:#10b981;
+      color:#fff;
+      font-size:64px;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      cursor:pointer;
+      box-shadow:0 2px 8px rgba(0,0,0,.15);
+    }
     .toolbar{display:flex;gap:10px;justify-content:flex-start;align-items:center;flex-wrap:wrap;}
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
@@ -41,8 +71,10 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <button id="playBtn" aria-label="Vis kvikkbilde">▶</button>
-        <div id="patternContainer" class="figure" aria-label="Kvikkbilder mønster"></div>
+        <div id="figureArea" class="figure-area">
+          <button id="playBtn" aria-label="Vis kvikkbilde">▶</button>
+          <div id="patternContainer" class="figure" aria-label="Kvikkbilder mønster"></div>
+        </div>
         <div id="expression"></div>
       </div>
       <div class="side">

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -24,27 +24,42 @@
       display:flex;flex-direction:column;gap:10px;
     }
     .card h2{margin:0 0 6px 2px;font-size:16px;font-weight:600;color:#374151;}
-    #brickContainer{
-      display:grid;
-      gap:10px;
-      justify-content:center;
+    .figure-area{
+      position:relative;
       width:min(80vmin,100%);
       aspect-ratio:1;
+      align-self:center;
+      margin:0 auto;
+    }
+    #brickContainer{
+      position:absolute;
+      inset:0;
+      display:grid;
+      gap:10px;
     }
     #brickContainer svg{width:100%;height:100%;}
-    #patternContainer{display:grid;gap:10px;justify-content:center;}
-    #patternContainer svg{height:auto;}
+    #patternContainer{
+      position:absolute;
+      inset:0;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+    }
+    #patternContainer svg{width:100%;height:100%;display:block;}
     #expression{text-align:center;font-size:24px;font-weight:600;}
     label{font-size:13px;color:#4b5563;display:flex;flex-direction:column;}
     input[type="number"], select{border:1px solid #d1d5db;border-radius:10px;padding:8px 10px;font-size:14px;background:#fff;}
     .checkbox-row{display:flex;align-items:center;gap:6px;}
     #playBtn{
-      align-self:center;
+      position:absolute;
+      top:50%;
+      left:50%;
+      transform:translate(-50%,-50%);
       padding:0;
-      font-size:40px;
+      font-size:64px;
       cursor:pointer;
-      width:100px;
-      height:100px;
+      width:160px;
+      height:160px;
       border:none;
       border-radius:50%;
       background:#10b981;
@@ -65,9 +80,11 @@
   <div class="wrap">
     <div class="grid">
       <div class="card">
-        <button id="playBtn" aria-label="Vis kvikkbilde">▶</button>
-        <div id="brickContainer" class="figure" aria-label="Kvikkbilder klosser"></div>
-        <div id="patternContainer" class="figure" aria-label="Kvikkbilder mønster"></div>
+        <div id="figureArea" class="figure-area">
+          <button id="playBtn" aria-label="Vis kvikkbilde">▶</button>
+          <div id="brickContainer" class="figure" aria-label="Kvikkbilder klosser"></div>
+          <div id="patternContainer" class="figure" aria-label="Kvikkbilder mønster"></div>
+        </div>
         <div id="expression"></div>
       </div>
       <div class="side">


### PR DESCRIPTION
## Summary
- keep the kvikkbilder display area a fixed square and center the play button on top
- let both klosser and mønster views use the same sized figure area so the play button and graphics align
- regenerate mønster SVGs with 10px radius dots, at least 3px spacing, and responsive sizing that fills the available space

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68c8789aab70832486dfcc49d7ce53c6