### PR TITLE
Adjust tenkeblokker layout

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -13,7 +13,7 @@
       color:#111827; background:#f7f8fb; padding:20px;
     }
     .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    .grid{display:grid;gap:var(--gap);grid-template-columns:minmax(0,1fr) minmax(320px,420px);align-items:start;}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
     @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     .card{
@@ -46,7 +46,7 @@
     .tb-settings{
       display:grid;
       gap:var(--gap);
-      grid-template-columns:repeat(auto-fit,minmax(260px,1fr));
+      grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
       align-items:start;
     }
     .addFigureBtn{
@@ -123,55 +123,6 @@
           <button id="tbAdd" class="addFigureBtn" type="button" aria-label="Legg til tenkeblokker">+</button>
         </div>
       </div>
-      <div class="card card--settings">
-        <h2>Innstillinger</h2>
-        <div class="tb-settings">
-          <fieldset id="cfg-fieldset-1">
-            <legend>Tenkeblokker 1</legend>
-            <label>Total
-              <input id="cfg-total-1" type="number" min="1" value="50" />
-            </label>
-            <label>Antall blokker
-              <input id="cfg-n-1" type="number" min="2" max="12" value="5" />
-            </label>
-            <label>Fylte blokker
-              <input id="cfg-k-1" type="number" min="0" max="5" value="4" />
-            </label>
-            <div class="checkbox-row"><input id="cfg-show-whole-1" type="checkbox" checked /><label for="cfg-show-whole-1">Vis hele</label></div>
-            <div class="checkbox-row"><input id="cfg-lock-n-1" type="checkbox" /><label for="cfg-lock-n-1">Lås nevner</label></div>
-            <div class="checkbox-row"><input id="cfg-hide-n-1" type="checkbox" /><label for="cfg-hide-n-1">Skjul n-verdi</label></div>
-            <label>Vis som
-              <select id="cfg-display-1">
-                <option value="number">Tall</option>
-                <option value="fraction">Brøk</option>
-                <option value="percent">Prosent</option>
-              </select>
-            </label>
-          </fieldset>
-          <fieldset id="cfg-fieldset-2" style="display:none">
-            <legend>Tenkeblokker 2</legend>
-            <label>Total
-              <input id="cfg-total-2" type="number" min="1" value="50" />
-            </label>
-            <label>Antall blokker
-              <input id="cfg-n-2" type="number" min="2" max="12" value="5" />
-            </label>
-            <label>Fylte blokker
-              <input id="cfg-k-2" type="number" min="0" max="5" value="3" />
-            </label>
-            <div class="checkbox-row"><input id="cfg-show-whole-2" type="checkbox" checked /><label for="cfg-show-whole-2">Vis hele</label></div>
-            <div class="checkbox-row"><input id="cfg-lock-n-2" type="checkbox" /><label for="cfg-lock-n-2">Lås nevner</label></div>
-            <div class="checkbox-row"><input id="cfg-hide-n-2" type="checkbox" /><label for="cfg-hide-n-2">Skjul n-verdi</label></div>
-            <label>Vis som
-              <select id="cfg-display-2">
-                <option value="number">Tall</option>
-                <option value="fraction">Brøk</option>
-                <option value="percent">Prosent</option>
-              </select>
-            </label>
-          </fieldset>
-        </div>
-      </div>
       <div class="side">
         <div class="card">
           <h2>Eksempler</h2>
@@ -181,10 +132,77 @@
           </div>
         </div>
         <div class="card">
-          <h2>Eksporter</h2>
+          <h2>Eksport</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
             <button id="btnPng" class="btn" type="button">Last ned PNG</button>
+          </div>
+        </div>
+        <div class="card card--settings">
+          <h2>Innstilling</h2>
+          <div id="tbSettings" class="tb-settings">
+            <fieldset id="cfg-fieldset-1">
+              <legend>Tenkeblokker 1</legend>
+              <label>Total
+                <input id="cfg-total-1" type="number" min="1" value="50" />
+              </label>
+              <label>Antall blokker
+                <input id="cfg-n-1" type="number" min="2" max="12" value="5" />
+              </label>
+              <label>Fylte blokker
+                <input id="cfg-k-1" type="number" min="0" max="5" value="4" />
+              </label>
+              <div class="checkbox-row">
+                <input id="cfg-show-whole-1" type="checkbox" checked />
+                <label for="cfg-show-whole-1">Vis hele</label>
+              </div>
+              <div class="checkbox-row">
+                <input id="cfg-lock-n-1" type="checkbox" />
+                <label for="cfg-lock-n-1">Lås nevner</label>
+              </div>
+              <div class="checkbox-row">
+                <input id="cfg-hide-n-1" type="checkbox" />
+                <label for="cfg-hide-n-1">Skjul n-verdi</label>
+              </div>
+              <label>Vis som
+                <select id="cfg-display-1">
+                  <option value="number">Tall</option>
+                  <option value="fraction">Brøk</option>
+                  <option value="percent">Prosent</option>
+                </select>
+              </label>
+            </fieldset>
+            <fieldset id="cfg-fieldset-2" style="display:none">
+              <legend>Tenkeblokker 2</legend>
+              <label>Total
+                <input id="cfg-total-2" type="number" min="1" value="50" />
+              </label>
+              <label>Antall blokker
+                <input id="cfg-n-2" type="number" min="2" max="12" value="5" />
+              </label>
+              <label>Fylte blokker
+                <input id="cfg-k-2" type="number" min="0" max="5" value="3" />
+              </label>
+              <div class="checkbox-row">
+                <input id="cfg-show-whole-2" type="checkbox" checked />
+                <label for="cfg-show-whole-2">Vis hele</label>
+              </div>
+              <div class="checkbox-row">
+                <input id="cfg-lock-n-2" type="checkbox" />
+                <label for="cfg-lock-n-2">Lås nevner</label>
+              </div>
+              <div class="checkbox-row">
+                <input id="cfg-hide-n-2" type="checkbox" />
+                <label for="cfg-hide-n-2">Skjul n-verdi</label>
+              </div>
+              <label>Vis som
+                <select id="cfg-display-2">
+                  <option value="number">Tall</option>
+                  <option value="fraction">Brøk</option>
+                  <option value="percent">Prosent</option>
+                </select>
+              </label>
+            </fieldset>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- move the think block preview into the left column and group the example, export and settings cards on the right
- widen the sidebar column and tune the settings grid so two think block fieldsets can sit side by side
- retitle the sidebar sections to match the requested labels

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c888bf78048324aef26918c0bb328f