### PR TITLE
Allow n=1 tenkeblokker defaults

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -105,7 +105,7 @@
             <svg id="thinkBlocks1" class="tb-svg" viewBox="0 0 900 420" aria-label="Tenkeblokker 1"></svg>
             <div class="tb-stepper" aria-label="Antall blokker i tenkeblokker 1">
               <button id="tbMinus1" type="button" aria-label="Færre blokker">−</button>
-              <span id="tbNVal1">5</span>
+              <span id="tbNVal1">1</span>
               <button id="tbPlus1" type="button" aria-label="Flere blokker">+</button>
             </div>
           </div>
@@ -115,7 +115,7 @@
             <svg id="thinkBlocks2" class="tb-svg" viewBox="0 0 900 420" aria-label="Tenkeblokker 2"></svg>
             <div class="tb-stepper" aria-label="Antall blokker i tenkeblokker 2">
               <button id="tbMinus2" type="button" aria-label="Færre blokker">−</button>
-              <span id="tbNVal2">5</span>
+              <span id="tbNVal2">1</span>
               <button id="tbPlus2" type="button" aria-label="Flere blokker">+</button>
             </div>
           </div>
@@ -147,10 +147,10 @@
                 <input id="cfg-total-1" type="number" min="1" value="50" />
               </label>
               <label>Antall blokker
-                <input id="cfg-n-1" type="number" min="2" max="12" value="5" />
+                <input id="cfg-n-1" type="number" min="1" max="12" value="1" />
               </label>
               <label>Fylte blokker
-                <input id="cfg-k-1" type="number" min="0" max="5" value="4" />
+                <input id="cfg-k-1" type="number" min="0" max="1" value="1" />
               </label>
               <div class="checkbox-row">
                 <input id="cfg-show-whole-1" type="checkbox" checked />
@@ -178,10 +178,10 @@
                 <input id="cfg-total-2" type="number" min="1" value="50" />
               </label>
               <label>Antall blokker
-                <input id="cfg-n-2" type="number" min="2" max="12" value="5" />
+                <input id="cfg-n-2" type="number" min="1" max="12" value="1" />
               </label>
               <label>Fylte blokker
-                <input id="cfg-k-2" type="number" min="0" max="5" value="3" />
+                <input id="cfg-k-2" type="number" min="0" max="1" value="0" />
               </label>
               <div class="checkbox-row">
                 <input id="cfg-show-whole-2" type="checkbox" checked />

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -2,8 +2,8 @@
 
 // ---------- Konfig ----------
 const DEFAULT_BLOCKS = [
-  { total: 50, n: 5, k: 4, showWhole: true, lockDenominator: false, hideNValue: false, valueDisplay: 'number' },
-  { total: 50, n: 5, k: 3, showWhole: true, lockDenominator: false, hideNValue: false, valueDisplay: 'number' }
+  { total: 50, n: 1, k: 1, showWhole: true, lockDenominator: false, hideNValue: false, valueDisplay: 'number' },
+  { total: 50, n: 1, k: 0, showWhole: true, lockDenominator: false, hideNValue: false, valueDisplay: 'number' }
 ];
 
 const DISPLAY_OPTIONS = ['number', 'fraction', 'percent'];
@@ -25,7 +25,7 @@ function applyDisplayMode(cfg, mode, fallback = 'number') {
 }
 
 const CONFIG = {
-  minN: 2,
+  minN: 1,
   maxN: 12,
   blocks: DEFAULT_BLOCKS.map(block => ({ ...block })),
   activeBlocks: 1
@@ -289,7 +289,7 @@ function normalizeConfig() {
   if (!Array.isArray(CONFIG.blocks)) CONFIG.blocks = [];
   if (CONFIG.blocks.length > 2) CONFIG.blocks.length = 2;
 
-  if (typeof CONFIG.minN !== 'number') CONFIG.minN = 2;
+  if (typeof CONFIG.minN !== 'number') CONFIG.minN = 1;
   if (typeof CONFIG.maxN !== 'number') CONFIG.maxN = 12;
   CONFIG.minN = Math.max(1, CONFIG.minN);
   CONFIG.maxN = Math.max(CONFIG.minN, CONFIG.maxN);


### PR DESCRIPTION
## Summary
- allow thinking blocks to be undivided by default (n = 1)
- update configuration validation so n can be set down to 1
- adjust UI defaults so newly added blocks start without subdivisions

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_68c901fbb4f483249712d55cd48d3cf2