### PR TITLE
Split think block settings when two blocks

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -44,10 +44,18 @@
     .tb-header{width:100%;display:flex;flex-direction:column;align-items:center;gap:6px;}
     .tb-header:empty{display:none;}
     .tb-settings{
-      display:grid;
+      display:flex;
+      flex-direction:column;
       gap:var(--gap);
-      grid-template-columns:repeat(auto-fit,minmax(200px,1fr));
-      align-items:start;
+      align-items:stretch;
+    }
+    .tb-settings.two{
+      flex-direction:row;
+      flex-wrap:wrap;
+    }
+    .tb-settings.two fieldset{
+      flex:1 1 160px;
+      min-width:0;
     }
     .addFigureBtn{
       width:clamp(30px,7.5vw,60px);

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -62,6 +62,8 @@ const panels = {
   addBtn: document.getElementById('tbAdd')
 };
 
+const settingsContainer = document.getElementById('tbSettings');
+
 createBlock(0);
 createBlock(1);
 
@@ -372,6 +374,7 @@ function updateVisibility() {
   if (panels.fieldset2) panels.fieldset2.style.display = showSecond ? '' : 'none';
   if (panels.addBtn) panels.addBtn.style.display = showSecond ? 'none' : '';
   panels.container?.classList.toggle('two', showSecond);
+  settingsContainer?.classList.toggle('two', showSecond);
 }
 
 function drawBlock(index) {


### PR DESCRIPTION
## Summary
- switch the think block settings container to a flex layout that can split into two columns
- toggle a helper class when two blocks are active so their fieldsets sit side by side

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c90c4f3b00832484275b90196f4b43