### PR TITLE
Increase spacing between kvikkbilder pattern units

### DIFF
--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -39,10 +39,20 @@
       justify-content:center;
       align-content:center;
       justify-items:center;
-      gap:18px;
+      gap:var(--pattern-gap, 18px);
+      padding:var(--pattern-padding, 0px);
       grid-template-columns:repeat(1,minmax(0,1fr));
       grid-template-rows:repeat(1,minmax(0,1fr));
       grid-auto-rows:minmax(0,1fr);
+    }
+    #patternContainer .pattern-item{
+      width:100%;
+      height:100%;
+      box-sizing:border-box;
+      display:flex;
+      align-items:center;
+      justify-content:center;
+      padding:var(--pattern-item-padding, 12px);
     }
     #patternContainer svg{width:100%;height:100%;display:block;}
     #expression{text-align:center;font-size:24px;font-weight:600;}

--- a/kvikkbilder-monster.js
+++ b/kvikkbilder-monster.js
@@ -213,6 +213,13 @@
     const rows=antallY>0?antallY:1;
     patternContainer.style.gridTemplateColumns=`repeat(${cols},minmax(0,1fr))`;
     patternContainer.style.gridTemplateRows=`repeat(${rows},minmax(0,1fr))`;
+    const maxDimension=Math.max(cols,rows);
+    const gapPx=maxDimension<=1?64:maxDimension===2?56:maxDimension===3?44:maxDimension===4?36:28;
+    const itemPaddingPx=Math.min(72,Math.max(18,Math.round(gapPx*0.65)));
+    const containerPaddingPx=Math.min(48,Math.max(12,Math.round(gapPx*0.4)));
+    patternContainer.style.setProperty('--pattern-gap',`${gapPx}px`);
+    patternContainer.style.setProperty('--pattern-item-padding',`${itemPaddingPx}px`);
+    patternContainer.style.setProperty('--pattern-padding',`${containerPaddingPx}px`);
 
     const points=byggMonster(n);
     const factors=primeFactors(n).filter(x=>x>1);
@@ -232,7 +239,10 @@
     const totalFigures=antallX*antallY;
     svg.setAttribute('aria-label', `Kvikkbilde ${n}`);
     for(let i=0;i<totalFigures;i++){
-      patternContainer.appendChild(svg.cloneNode(true));
+      const wrapper=document.createElement('div');
+      wrapper.className='pattern-item';
+      wrapper.appendChild(svg.cloneNode(true));
+      patternContainer.appendChild(wrapper);
     }
 
     if(totalFigures>1){


### PR DESCRIPTION
## Summary
- add layout variables so pattern tiles get generous padding and gap inside the grid
- wrap each generated SVG in a flex container and calculate gap/padding dynamically based on grid size

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c928736fa08324be40422ba35e2195