### PR TITLE
Fix graftegner initialization errors

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -956,8 +956,10 @@ function buildFunctions(){
 }
 
 /* =================== LINJE FRA PUNKTER =================== */
-let A=null, B=null, moving=[];
 function buildPointsLine(){
+  A = null;
+  B = null;
+  moving = [];
   const first = SIMPLE_PARSED.funcs[0] ?? {rhs:'ax+b'};
   const rhs = first.rhs.replace(/\s+/g,'').toLowerCase();
 
@@ -1116,7 +1118,17 @@ function rebuildAll(){
 }
 
 window.addEventListener('resize', ()=>{
-  JXG.JSXGraph.resizeBoards();
+  const resizeBoards = JXG?.JSXGraph?.resizeBoards;
+  if(typeof resizeBoards === 'function'){
+    resizeBoards();
+  }else if(brd && typeof brd.resizeContainer === 'function'){
+    const cw = brd.containerObj?.clientWidth;
+    const ch = brd.containerObj?.clientHeight;
+    if(cw && ch){
+      brd.resizeContainer(cw, ch);
+      brd.update();
+    }
+  }
   updateAfterViewChange();
 });
 


### PR DESCRIPTION
## Summary
- reset the shared point references when building the line-from-points mode instead of redeclaring them, so graftegner.js loads without crashing
- guard the resize handler to cope with JSXGraph builds that do not expose `resizeBoards`, preventing another runtime error

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68c93fb6b50483249a0f958e7e7c8d65