### PR TITLE
Ensure right-triangle freeform specs stay within three values

### DIFF
--- a/nkant.js
+++ b/nkant.js
@@ -260,14 +260,28 @@ function parseSpecFreeform(str){
   }
 
   if(/rettvinkle[dt]/.test(text) && /trekant/.test(text)){
+    const rightLetter = ["A","B","C"].find(L => out[L] === 90) || "C";
+    const legKeys = rightLetter === "A" ? ["b","c"]
+                   : rightLetter === "B" ? ["a","c"]
+                   : ["a","b"];
+
     if(nums.length === 2){
       const [x,y] = nums;
-      out.a = x; out.b = y; out.c = Math.hypot(x,y); out.C = 90;
-    }else if(nums.length === 0){
-      const k = rand(1,4);
-      Object.assign(out, {a:3*k, b:4*k, c:5*k, C:90});
+      out[legKeys[0]] = x;
+      out[legKeys[1]] = y;
+      out[rightLetter] = 90;
+      return out;
     }
-    return out;
+
+    if(nums.length === 0){
+      const k = rand(1,4);
+      out[legKeys[0]] = 3*k;
+      out[legKeys[1]] = 4*k;
+      out[rightLetter] = 90;
+      return out;
+    }
+
+    out[rightLetter] = 90;
   }
 
   if(/trekant/.test(text) && nums.length === 0){


### PR DESCRIPTION
## Summary
- update the right-triangle freeform parser to return only two leg lengths and the right angle so triangles expose three properties
- honour an explicitly mentioned right-angle vertex while generating default leg values

## Testing
- node <<'NODE'
  global.window = { addEventListener: ()=>{} };
  const fs = require('fs');
  const vm = require('vm');
  const code = fs.readFileSync('nkant.js', 'utf8');
  vm.runInThisContext(code);
  function test(input){
    const res = parseSpecFreeform(input);
    console.log(input, '=>', res);
  }
  test('Rettvinklet trekant');
  test('rettvinklet trekant med kateter 3 og 4');
  test('rettvinklet trekant rett vinkel i B med kateter 3 og 4');
NODE

------
https://chatgpt.com/codex/tasks/task_e_68c95b29b5f883249251045e20e9de59