### PR TITLE
Ensure example saves use current settings

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -14,6 +14,25 @@
   }
   const BINDING_NAMES = ['STATE','CFG','CONFIG','SIMPLE'];
 
+  function flushPendingChanges(){
+    const fields = document.querySelectorAll('input, textarea, select');
+    fields.forEach(field => {
+      ['input', 'change'].forEach(type => {
+        try{
+          field.dispatchEvent(new Event(type, {bubbles:true}));
+        }catch(_){ }
+      });
+    });
+    const syncFns = ['applyCfg', 'applyConfig'];
+    syncFns.forEach(name => {
+      const fn = window[name];
+      if(typeof fn === 'function'){
+        try{ fn(); }
+        catch(_){ }
+      }
+    });
+  }
+
   function ensureTabStyles(){
     if(document.getElementById('exampleTabStyles')) return;
     const style = document.createElement('style');
@@ -114,6 +133,7 @@
   }
 
   function collectConfig(){
+    flushPendingChanges();
     const cfg = {};
     for(const name of BINDING_NAMES){
       const binding = getBinding(name);


### PR DESCRIPTION
## Summary
- ensure inputs dispatch change events before collecting stored examples
- invoke available configuration sync functions so the latest settings are saved

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68c981307d448324ab672011815dcaf5