### PR TITLE
Make top navigation icon based

### DIFF
--- a/index.html
+++ b/index.html
@@ -41,31 +41,51 @@
       flex: 0 0 auto;
     }
     nav a {
-      color: #147a9c;
+      position: relative;
+      color: #0f6d8f;
       text-decoration: none;
       display: inline-flex;
-      gap: 0.5rem;
       align-items: center;
-      padding: 6px 10px;
-      border-radius: 9999px;
-      transition: background-color 0.15s ease, color 0.15s ease;
+      justify-content: center;
+      width: 3.25rem;
+      height: 3.25rem;
+      border-radius: 1rem;
+      background: #e6f4fa;
+      box-shadow: inset 0 0 0 1px rgba(15, 109, 143, 0.08);
+      transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
     }
     nav a:hover {
-      background: rgba(20, 122, 156, 0.1);
+      background: #0f6d8f;
+      color: #fff;
+      transform: translateY(-1px);
+      box-shadow: 0 6px 12px rgba(15, 109, 143, 0.25);
     }
     nav a.active {
-      background: #e5e7eb;
-      font-weight: 600;
+      background: #0f6d8f;
+      color: #fff;
+      box-shadow: 0 4px 10px rgba(15, 109, 143, 0.2);
     }
     nav a:focus,
     nav a:focus-visible {
-      outline: 2px solid #111827;
-      outline-offset: 2px;
+      outline: 3px solid rgba(15, 109, 143, 0.35);
+      outline-offset: 3px;
     }
     nav svg {
-      width: 1.25rem;
-      height: 1.25rem;
+      width: 1.75rem;
+      height: 1.75rem;
       flex-shrink: 0;
+      stroke-width: 1.75;
+    }
+    .sr-only {
+      position: absolute;
+      width: 1px;
+      height: 1px;
+      padding: 0;
+      margin: -1px;
+      overflow: hidden;
+      clip: rect(0, 0, 0, 0);
+      white-space: nowrap;
+      border: 0;
     }
     iframe {
       border: 0;
@@ -96,7 +116,12 @@
         font-size: 18px;
       }
       nav a {
-        padding: 6px 8px;
+        width: 2.75rem;
+        height: 2.75rem;
+      }
+      nav svg {
+        width: 1.5rem;
+        height: 1.5rem;
       }
     }
   </style>
@@ -105,19 +130,84 @@
   <nav>
     <h1>Velg visualisering</h1>
     <ul>
-        <li><a href="graftegner.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18"/><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4-4 4 6 6-10"/></svg>Graftegner</a></li>
-        <li><a href="nkant.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><polygon stroke-linejoin="round" points="12 4 20 20 4 20"/></svg>nKant</a></li>
-        <li><a href="diagram/index.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/></svg>Diagram</a></li>
-        <li><a href="brøkpizza.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z"/></svg>Brøkpizza</a></li>
-        <li><a href="brøkfigurer.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><polygon points="4 20 12 20 12 4" fill="currentColor"/><polygon points="4 20 20 20 12 4"/><path stroke-linecap="round" d="M12 4v16"/></svg>Brøkfigurer</a></li>
-        <li><a href="figurtall.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><rect x="3" y="15" width="6" height="6" fill="currentColor" stroke="none"/><rect x="9" y="9" width="6" height="6" fill="currentColor" stroke="none"/><rect x="9" y="15" width="6" height="6" fill="currentColor" stroke="none"/><rect x="15" y="3" width="6" height="6" fill="currentColor" stroke="none"/><rect x="15" y="9" width="6" height="6" fill="currentColor" stroke="none"/><rect x="15" y="15" width="6" height="6" fill="currentColor" stroke="none"/></svg>Figurtall</a></li>
-        <li><a href="tenkeblokker.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" d="M4 7h16M4 7v4M20 7v4"/><rect x="5" y="11" width="4" height="4" fill="currentColor" stroke="none"/><rect x="10" y="11" width="4" height="4" fill="currentColor" stroke="none"/><rect x="15" y="11" width="4" height="4" fill="currentColor" stroke="none"/></svg>Tenkeblokker</a></li>
-        <li><a href="arealmodell0.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><rect x="3" y="6" width="18" height="12"/><path stroke-linecap="round" d="M9 6v12M15 6v12M3 12h18"/><circle cx="21" cy="5" r="1.5"/></svg>Arealmodell A</a></li>
-        <li><a href="arealmodellen1.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><rect x="3" y="4" width="18" height="15"/><path d="M4.5 4v15M6 4v15M7.5 4v15M9 4v15M10.5 4v15M12 4v15M13.5 4v15M15 4v15M16.5 4v15M18 4v15M19.5 4v15M3 5h18M3 6h18M3 7h18M3 8h18M3 9h18M3 10h18M3 11h18M3 12h18M3 13h18M3 14h18M3 15h18M3 16h18M3 17h18M3 18h18"/><path stroke-linecap="round" stroke-linejoin="round" d="M21 11.5l2 1.5-2 1.5"/></svg>Arealmodell B</a></li>
-        <li><a href="perlesnor.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M2 12h20"/><circle cx="6" cy="12" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="18" cy="12" r="1.5"/></svg>Perlesnor</a></li>
-        <li><a href="kuler.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M3 11q9 9 18 0"/><circle cx="9" cy="13" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="13" r="1.5" fill="currentColor" stroke="none"/><circle cx="15" cy="13" r="1.5" fill="currentColor" stroke="none"/></svg>Kuler</a></li>
-        <li><a href="kvikkbilder.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><circle cx="6" cy="8" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="8" r="1.5" fill="currentColor" stroke="none"/><circle cx="18" cy="8" r="1.5" fill="currentColor" stroke="none"/><circle cx="6" cy="16" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="16" r="1.5" fill="currentColor" stroke="none"/><circle cx="18" cy="16" r="1.5" fill="currentColor" stroke="none"/></svg>Kvikkbilder</a></li>
-        <li><a href="examples.html" target="content"><svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/></svg>Eksempler</a></li>
+      <li>
+        <a href="graftegner.html" target="content" title="Graftegner" aria-label="Graftegner">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18"/><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4-4 4 6 6-10"/></svg>
+          <span class="sr-only">Graftegner</span>
+        </a>
+      </li>
+      <li>
+        <a href="nkant.html" target="content" title="nKant" aria-label="nKant">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><polygon stroke-linejoin="round" points="12 4 20 20 4 20"/></svg>
+          <span class="sr-only">nKant</span>
+        </a>
+      </li>
+      <li>
+        <a href="diagram/index.html" target="content" title="Diagram" aria-label="Diagram">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75ZM9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625ZM16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z"/></svg>
+          <span class="sr-only">Diagram</span>
+        </a>
+      </li>
+      <li>
+        <a href="brøkpizza.html" target="content" title="Brøkpizza" aria-label="Brøkpizza">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z"/><path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z"/></svg>
+          <span class="sr-only">Brøkpizza</span>
+        </a>
+      </li>
+      <li>
+        <a href="brøkfigurer.html" target="content" title="Brøkfigurer" aria-label="Brøkfigurer">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><polygon points="4 20 12 20 12 4" fill="currentColor"/><polygon points="4 20 20 20 12 4"/><path stroke-linecap="round" d="M12 4v16"/></svg>
+          <span class="sr-only">Brøkfigurer</span>
+        </a>
+      </li>
+      <li>
+        <a href="figurtall.html" target="content" title="Figurtall" aria-label="Figurtall">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><rect x="3" y="15" width="6" height="6" fill="currentColor" stroke="none"/><rect x="9" y="9" width="6" height="6" fill="currentColor" stroke="none"/><rect x="9" y="15" width="6" height="6" fill="currentColor" stroke="none"/><rect x="15" y="3" width="6" height="6" fill="currentColor" stroke="none"/><rect x="15" y="9" width="6" height="6" fill="currentColor" stroke="none"/><rect x="15" y="15" width="6" height="6" fill="currentColor" stroke="none"/></svg>
+          <span class="sr-only">Figurtall</span>
+        </a>
+      </li>
+      <li>
+        <a href="tenkeblokker.html" target="content" title="Tenkeblokker" aria-label="Tenkeblokker">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" d="M4 7h16M4 7v4M20 7v4"/><rect x="5" y="11" width="4" height="4" fill="currentColor" stroke="none"/><rect x="10" y="11" width="4" height="4" fill="currentColor" stroke="none"/><rect x="15" y="11" width="4" height="4" fill="currentColor" stroke="none"/></svg>
+          <span class="sr-only">Tenkeblokker</span>
+        </a>
+      </li>
+      <li>
+        <a href="arealmodell0.html" target="content" title="Arealmodell A" aria-label="Arealmodell A">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><rect x="3" y="6" width="18" height="12"/><path stroke-linecap="round" d="M9 6v12M15 6v12M3 12h18"/><circle cx="21" cy="5" r="1.5"/></svg>
+          <span class="sr-only">Arealmodell A</span>
+        </a>
+      </li>
+      <li>
+        <a href="arealmodellen1.html" target="content" title="Arealmodell B" aria-label="Arealmodell B">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><rect x="3" y="4" width="18" height="15"/><path d="M4.5 4v15M6 4v15M7.5 4v15M9 4v15M10.5 4v15M12 4v15M13.5 4v15M15 4v15M16.5 4v15M18 4v15M19.5 4v15M3 5h18M3 6h18M3 7h18M3 8h18M3 9h18M3 10h18M3 11h18M3 12h18M3 13h18M3 14h18M3 15h18M3 16h18M3 17h18M3 18h18"/><path stroke-linecap="round" stroke-linejoin="round" d="M21 11.5l2 1.5-2 1.5"/></svg>
+          <span class="sr-only">Arealmodell B</span>
+        </a>
+      </li>
+      <li>
+        <a href="perlesnor.html" target="content" title="Perlesnor" aria-label="Perlesnor">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M2 12h20"/><circle cx="6" cy="12" r="1.5"/><circle cx="12" cy="12" r="1.5"/><circle cx="18" cy="12" r="1.5"/></svg>
+          <span class="sr-only">Perlesnor</span>
+        </a>
+      </li>
+      <li>
+        <a href="kuler.html" target="content" title="Kuler" aria-label="Kuler">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 11q9 9 18 0"/><circle cx="9" cy="13" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="13" r="1.5" fill="currentColor" stroke="none"/><circle cx="15" cy="13" r="1.5" fill="currentColor" stroke="none"/></svg>
+          <span class="sr-only">Kuler</span>
+        </a>
+      </li>
+      <li>
+        <a href="kvikkbilder.html" target="content" title="Kvikkbilder" aria-label="Kvikkbilder">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><circle cx="6" cy="8" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="8" r="1.5" fill="currentColor" stroke="none"/><circle cx="18" cy="8" r="1.5" fill="currentColor" stroke="none"/><circle cx="6" cy="16" r="1.5" fill="currentColor" stroke="none"/><circle cx="12" cy="16" r="1.5" fill="currentColor" stroke="none"/><circle cx="18" cy="16" r="1.5" fill="currentColor" stroke="none"/></svg>
+          <span class="sr-only">Kvikkbilder</span>
+        </a>
+      </li>
+      <li>
+        <a href="examples.html" target="content" title="Eksempler" aria-label="Eksempler">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16"/></svg>
+          <span class="sr-only">Eksempler</span>
+        </a>
+      </li>
     </ul>
   </nav>
     <iframe name="content" title="Innhold"></iframe>


### PR DESCRIPTION
## Summary
- update the top navigation to use icon-only links with accessible labels and hover tooltips
- enlarge and restyle the navigation icons for clearer visuals and stronger hover/focus states
- tweak responsive sizing so the icon menu scales down on small screens

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_e_68c98ab83fbc83249fe8a808d47514f5