### PR TITLE
Update graftegner icon to parabola

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@
     <ul>
       <li>
         <a href="graftegner.html" target="content" title="Graftegner" aria-label="Graftegner">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18"/><path stroke-linecap="round" stroke-linejoin="round" d="M5 13l4-4 4 6 6-10"/></svg>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true"><path stroke-linecap="round" stroke-linejoin="round" d="M3 3v18h18"/><path stroke-linecap="round" stroke-linejoin="round" d="M6.5 8.5Q12 21 17.5 8.5"/></svg>
           <span class="sr-only">Graftegner</span>
         </a>
       </li>


### PR DESCRIPTION
## Summary
- replace the Graftegner navigation icon with a parabola drawn inside the coordinate axes

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c9a17cc4e08324844ff6e6b37ff47a