### PR TITLE
Hide example/settings headings and remove extra tab divider

### DIFF
--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -59,15 +59,13 @@
         </div>
       </div>
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <div id="settingsMenu" class="settings">
             <div class="row">
               <label>Lengde (celler)

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -66,15 +66,13 @@
         <svg id="area" preserveAspectRatio="xMidYMid meet" aria-label="Arealmodell"></svg>
       </div>
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <div class="settings">
             <div class="row">
               <label>Lengde

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -116,15 +116,13 @@
         </div>
       </div>
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <fieldset>
             <legend>Farger</legend>
             <label>Antall farger

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -184,16 +184,14 @@
       </div>
 
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <div class="settings">
           <fieldset>
             <legend>Pizza 1</legend>

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -30,16 +30,14 @@
       </div>
 
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <div class="settings">
           <fieldset>
             <legend>Diagram</legend>

--- a/examples.js
+++ b/examples.js
@@ -38,7 +38,7 @@
     const style = document.createElement('style');
     style.id = 'exampleTabStyles';
     style.textContent = `
-.example-tabs{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px;margin-bottom:0;align-items:flex-end;border-bottom:1px solid #e5e7eb;padding-bottom:0;}
+.example-tabs{display:flex;flex-wrap:wrap;gap:6px;margin-top:10px;margin-bottom:0;align-items:flex-end;padding-bottom:0;}
 .example-tab{appearance:none;border:1px solid #d1d5db;border-bottom:none;background:#f3f4f6;color:#374151;border-radius:10px 10px 0 0;padding:6px 14px;font-size:14px;line-height:1;cursor:pointer;transition:background-color .2s,border-color .2s,color .2s;box-shadow:0 -1px 0 rgba(15,23,42,.08) inset;margin-bottom:-1px;}
 .example-tab:hover{background:#e5e7eb;}
 .example-tab.is-active{background:#fff;color:#111827;border-color:var(--purple,#5B2AA5);border-bottom:1px solid #fff;box-shadow:0 -2px 0 var(--purple,#5B2AA5) inset;}
@@ -66,9 +66,13 @@
         candidate = candidate.nextElementSibling;
         continue;
       }
+      if(candidate.classList.contains('card--settings') || candidate.getAttribute('data-card') === 'settings'){
+        settingsCard = candidate;
+        break;
+      }
       const heading = candidate.querySelector(':scope > h2');
       const text = heading ? heading.textContent.trim().toLowerCase() : '';
-      if(text === 'innstillinger'){
+      if(text === 'innstillinger' || text === 'innstilling'){
         settingsCard = candidate;
         break;
       }

--- a/figurtall.html
+++ b/figurtall.html
@@ -145,15 +145,13 @@
         </div>
       </div>
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <fieldset>
             <legend>Ruter</legend>
             <label>Rader

--- a/graftegner.html
+++ b/graftegner.html
@@ -60,16 +60,14 @@
       </div>
 
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <div class="settings">
             <div id="funcRows"></div>
             <fieldset>

--- a/kuler.html
+++ b/kuler.html
@@ -82,15 +82,13 @@
         </div>
       </div>
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempler</button>
             <button id="btnDeleteExample" class="btn" type="button">Slette eksempler</button>
           </div>
         </div>
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <div id="controls" class="controlsWrap"></div>
         </div>
         <div class="card">

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -95,15 +95,13 @@
         <div id="expression"></div>
       </div>
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <label>Vis play-knapp
             <input id="cfg-showBtn" type="checkbox">
           </label>

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -97,15 +97,13 @@
         <div id="expression"></div>
       </div>
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <label>Type
             <select id="cfg-type">
               <option value="klosser">Klosser</option>

--- a/nkant.html
+++ b/nkant.html
@@ -48,16 +48,14 @@
       </div>
 
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
 
         <label for="inpSpecs">Skriv spesifikasjoner eller fritekst (1–2 linjer per figur)</label>
         <div class="specs-row">

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -69,16 +69,14 @@
       </div>
 
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
 
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <label>Antall perler<input id="cfg-nBeads" type="number" min="1"></label>
           <label>Startposisjon<input id="cfg-startIndex" type="number" min="0"></label>
           <label>Fasit venstre<input id="cfg-correct" type="number" min="0"></label>

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -52,15 +52,13 @@
         </div>
       </div>
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <p class="muted">Ingen ekstra innstillinger for denne visningen.</p>
         </div>
         <div class="card">

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -134,8 +134,7 @@
         </div>
       </div>
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
@@ -149,7 +148,6 @@
           </div>
         </div>
         <div class="card card--settings">
-          <h2>Innstilling</h2>
           <div id="tbSettings" class="tb-settings">
             <fieldset id="cfg-fieldset-1">
               <legend>Tenkeblokker 1</legend>

--- a/trefigurer.html
+++ b/trefigurer.html
@@ -128,15 +128,13 @@
         </div>
       </div>
       <div class="side">
-        <div class="card">
-          <h2>Eksempler</h2>
+        <div class="card card--examples">
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>
           </div>
         </div>
-        <div class="card">
-          <h2>Innstillinger</h2>
+        <div class="card card--settings">
           <label for="inpSpecs">Skriv fritekst (én figur per linje)</label>
           <div class="specs-row">
             <textarea id="inpSpecs" rows="4" spellcheck="false">kule</textarea>


### PR DESCRIPTION
## Summary
- hide the "Eksempler" and "Innstillinger" headings in the side cards across the interactive tools by adding dedicated card classes
- adjust the example tabs styling to remove the extra divider and update the examples script to rely on the new card classes when relocating settings content

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68c9c668fdc8832483b1855c04ad859f