### PR TITLE
Add export buttons and capture for 3D figures

### DIFF
--- a/trefigurer.html
+++ b/trefigurer.html
@@ -212,6 +212,17 @@
             </label>
           </div>
         </div>
+        <div class="card card--export">
+          <h2>Eksporter</h2>
+          <div class="toolbar exportToolbar" data-export-index="0" hidden>
+            <button class="btn" type="button" data-export-type="svg">Last ned SVG</button>
+            <button class="btn" type="button" data-export-type="png">Last ned PNG</button>
+          </div>
+          <div class="toolbar exportToolbar" data-export-index="1" hidden>
+            <button class="btn" type="button" data-export-type="svg">Last ned SVG</button>
+            <button class="btn" type="button" data-export-type="png">Last ned PNG</button>
+          </div>
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add an export card to the 3D figures view with SVG and PNG download buttons for each figure
- capture the WebGL canvas as a PNG with a matching background and wrap it in SVG for vector downloads
- toggle export controls based on which figures are currently rendered

## Testing
- Manual verification via `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68ca53e8148083249e4d9a405a321edd