### PR TITLE
Add vertical camera angle slider to 3D figures

### DIFF
--- a/trefigurer.html
+++ b/trefigurer.html
@@ -245,6 +245,13 @@
           </div>
           <div class="option-row option-row--slider option-row--view">
             <div class="option-row__header">
+              <label for="rngViewElevation">Vinkel opp/ned (<span data-view-figure-label>Figur 1</span>): <span id="lblViewElevation">0°</span></label>
+              <div class="option-hint">Juster kameravinkelen vertikalt.</div>
+            </div>
+            <input id="rngViewElevation" class="range-input" type="range" min="-80" max="80" step="1" value="0" />
+          </div>
+          <div class="option-row option-row--slider option-row--view">
+            <div class="option-row__header">
               <label for="rngViewZoom">Zoom (<span data-view-figure-label>Figur 1</span>): <span id="lblViewZoom">100%</span></label>
               <div class="option-hint">100% tilsvarer standardavstanden.</div>
             </div>


### PR DESCRIPTION
## Summary
- add a new UI slider to control the vertical camera angle for 3D figures
- wire the slider into the renderer so elevation changes are clamped, stored, and reflected in labels
- update view state synchronization to keep the new control in sync with orbit controls and exports

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca723204b88324833f1e0d5f069d9e