### PR TITLE
Ensure saved examples ignore temporary fills

### DIFF
--- a/brøkfigurer.js
+++ b/brøkfigurer.js
@@ -825,6 +825,36 @@
     STATE.figure2Visible = false;
     window.render();
   });
+
+  window.addEventListener('examples:collect', (event)=>{
+    const detail = event?.detail;
+    if(!detail || detail.svgOverride != null) return;
+    const restore = [];
+    for(const fig of figures){
+      if(!fig || typeof fig.getFilled !== 'function' || typeof fig.setFilled !== 'function') continue;
+      let filled = fig.getFilled();
+      if(filled instanceof Map){
+        if(filled.size === 0) continue;
+      }else if(filled && typeof filled[Symbol.iterator] === 'function'){
+        filled = new Map(filled);
+        if(filled.size === 0) continue;
+      }else{
+        continue;
+      }
+      restore.push({fig, filled});
+    }
+    if(restore.length === 0) return;
+    for(const {fig} of restore){
+      fig.setFilled(new Map());
+    }
+    window.render?.();
+    const svg = document.querySelector('svg');
+    if(svg) detail.svgOverride = svg.outerHTML;
+    for(const {fig, filled} of restore){
+      fig.setFilled(filled);
+    }
+    window.render?.();
+  });
   window.render();
 })();
 

--- a/examples.js
+++ b/examples.js
@@ -256,15 +256,26 @@
 
   function collectConfig(){
     flushPendingChanges();
+    const collectionDetail = {svgOverride:null};
     try{
       if(typeof window !== 'undefined' && window){
-        const evt = typeof CustomEvent === 'function'
-          ? new CustomEvent('examples:collect')
-          : new Event('examples:collect');
+        let evt;
+        if(typeof CustomEvent === 'function'){
+          evt = new CustomEvent('examples:collect', {detail:collectionDetail});
+        }else{
+          evt = new Event('examples:collect');
+          try{ evt.detail = collectionDetail; }
+          catch(_){ }
+        }
         window.dispatchEvent(evt);
       }
     }catch(_){
-      try{ window.dispatchEvent(new Event('examples:collect')); }
+      try{
+        const evt = new Event('examples:collect');
+        try{ evt.detail = collectionDetail; }
+        catch(_){ }
+        window.dispatchEvent(evt);
+      }
       catch(_){ }
     }
     const cfg = {};
@@ -274,8 +285,18 @@
         cfg[name] = cloneValue(binding);
       }
     }
-    const svg = document.querySelector('svg');
-    return {config: cfg, svg: svg ? svg.outerHTML : ''};
+    let svgMarkup = '';
+    if(collectionDetail.svgOverride != null){
+      if(typeof collectionDetail.svgOverride === 'string') svgMarkup = collectionDetail.svgOverride;
+      else if(collectionDetail.svgOverride && typeof collectionDetail.svgOverride.outerHTML === 'string'){
+        svgMarkup = collectionDetail.svgOverride.outerHTML;
+      }
+    }
+    if(!svgMarkup){
+      const svg = document.querySelector('svg');
+      svgMarkup = svg ? svg.outerHTML : '';
+    }
+    return {config: cfg, svg: svgMarkup};
   }
 
   function loadExample(index){


### PR DESCRIPTION
## Summary
- allow tools to override the SVG snapshot that gets stored with saved examples
- temporarily clear custom fills when collecting Brøkfigurer examples so saved previews show unmarked shapes

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68ca74e13334832497cbc0f85e207a75