### PR TITLE
Update Trefigurer icon to cylinder

### DIFF
--- a/index.html
+++ b/index.html
@@ -250,10 +250,11 @@
       <li>
         <a href="trefigurer.html" target="content" title="Trefigurer" aria-label="Trefigurer">
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
-            <path d="M12 3 4 7v10l8 4 8-4V7Z" fill="currentColor" fill-opacity=".25" />
-            <path d="M12 3v10l8 4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-linecap="round" stroke-width="1.4" />
-            <path d="M12 3 4 7l8 4 8-4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.4" />
-            <path d="M4 7v10l8 4" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.4" />
+            <path d="M6 6v8c0 2.05 2.686 3.7 6 3.7s6-1.65 6-3.7V6c0 2.05-2.686 3.7-6 3.7S6 8.05 6 6Z" fill="currentColor" fill-opacity=".15" />
+            <ellipse cx="12" cy="6" rx="6" ry="3.2" fill="currentColor" fill-opacity=".2" />
+            <path d="M6 6c0 1.768 2.686 3.2 6 3.2s6-1.432 6-3.2S16.314 2.8 12 2.8 6 4.232 6 6Z" fill="none" stroke="currentColor" stroke-width="1.4" />
+            <path d="M6 6v8c0 1.768 2.686 3.2 6 3.2s6-1.432 6-3.2V6" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.4" />
+            <path d="M6 14c0 1.768 2.686 3.2 6 3.2s6-1.432 6-3.2" fill="none" stroke="currentColor" stroke-linecap="round" stroke-width="1.4" />
           </svg>
           <span class="sr-only">Trefigurer</span>
         </a>


### PR DESCRIPTION
## Summary
- redesign the Trefigurer menu SVG to depict a cylinder with translucent fill and clear outline

## Testing
- no automated tests were run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68cac2ea4a5c83249053236f288f83a9