### PR TITLE
Add Safari fallback for Kvikkbilder layout

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -31,6 +31,13 @@
       align-self:center;
       margin:0 auto;
     }
+    @supports not (aspect-ratio: 1 / 1) {
+      .figure-area::before {
+        content:"";
+        display:block;
+        padding-bottom:100%;
+      }
+    }
     #brickContainer{
       position:absolute;
       inset:0;


### PR DESCRIPTION
## Summary
- add a CSS fallback to preserve the Kvikkbilder figure area's height when aspect-ratio is unsupported

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cbea88243c8324964bcba6b85ce578