### PR TITLE
Move fortegnsskjema to end of menu and mark visualization as under development

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -21,6 +21,33 @@
       flex-direction: column;
       gap: var(--gap);
     }
+    .development-banner {
+      display: flex;
+      align-items: flex-start;
+      gap: 12px;
+      padding: 14px 18px;
+      border-radius: 12px;
+      border: 1px solid rgba(217, 119, 6, 0.4);
+      background: linear-gradient(120deg, rgba(255, 237, 213, 0.95), rgba(255, 247, 237, 0.95));
+      color: #92400e;
+      font-size: 14px;
+      line-height: 1.5;
+    }
+    .development-banner svg {
+      width: 22px;
+      height: 22px;
+      flex-shrink: 0;
+    }
+    .development-banner__text {
+      display: flex;
+      flex-direction: column;
+      gap: 4px;
+    }
+    .development-banner__text strong {
+      font-size: 15px;
+      font-weight: 600;
+      color: inherit;
+    }
     .grid {
       display: grid;
       gap: var(--gap);
@@ -162,6 +189,16 @@
 </head>
 <body>
   <div class="wrap">
+    <div class="development-banner" role="note">
+      <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M12 9v4m0 4h.01" />
+        <path stroke-linecap="round" stroke-linejoin="round" d="M10.29 3.86 1.82 18a1.8 1.8 0 0 0 1.55 2.7h17.26a1.8 1.8 0 0 0 1.55-2.7L13.11 3.86a1.8 1.8 0 0 0-2.82 0Z" />
+      </svg>
+      <div class="development-banner__text">
+        <strong>Under utvikling</strong>
+        <span>Vi jobber fortsatt med denne visualiseringen. Funksjoner kan mangle eller endre seg.</span>
+      </div>
+    </div>
     <div class="grid">
       <div class="card">
         <h1>Fortegnsskjema</h1>

--- a/index.html
+++ b/index.html
@@ -49,6 +49,20 @@
       box-shadow: inset 0 0 0 1px rgba(15, 109, 143, 0.08);
       transition: background-color 0.2s ease, color 0.2s ease, transform 0.2s ease, box-shadow 0.2s ease;
     }
+    .nav-badge {
+      position: absolute;
+      top: -6px;
+      right: -6px;
+      padding: 2px 6px;
+      border-radius: 999px;
+      background: #f97316;
+      color: #fff;
+      font-size: 0.65rem;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+      text-transform: uppercase;
+      box-shadow: 0 4px 10px rgba(249, 115, 22, 0.25);
+    }
     nav a:hover {
       background: #0f6d8f;
       color: #fff;
@@ -146,16 +160,6 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 4.125c0-.621.504-1.125 1.125-1.125h2.25C20.496 3 21 3.504 21 4.125v15.75c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V4.125Z" />
           </svg>
           <span class="sr-only">Diagram</span>
-        </a>
-      </li>
-      <li>
-        <a href="fortegnsskjema.html" target="content" title="Fortegnsskjema" aria-label="Fortegnsskjema">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h13.5m0 0 2.5-2.5M17.5 6l2.5 2.5" />
-            <path stroke-linecap="round" stroke-linejoin="round" d="M4 12h14" />
-            <path stroke-linecap="round" stroke-linejoin="round" d="M4 18h7" stroke-dasharray="3 2" />
-          </svg>
-          <span class="sr-only">Fortegnsskjema</span>
         </a>
       </li>
       <li>
@@ -277,6 +281,17 @@
             <rect x="4" y="16" width="16" height="4" rx="1.5" />
           </svg>
           <span class="sr-only">Brøkvegg</span>
+        </a>
+      </li>
+      <li>
+        <a href="fortegnsskjema.html" target="content" title="Fortegnsskjema – under utvikling" aria-label="Fortegnsskjema, under utvikling">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h13.5m0 0 2.5-2.5M17.5 6l2.5 2.5" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 12h14" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 18h7" stroke-dasharray="3 2" />
+          </svg>
+          <span class="sr-only">Fortegnsskjema</span>
+          <span class="nav-badge" aria-hidden="true">Beta</span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
## Summary
- move the Fortegnsskjema entry to the end of the main menu and add a beta badge in the navigation
- introduce a banner on the Fortegnsskjema page that communicates the visualization is still under development

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68cc01da65888324b82aa100a81e6618