### PR TITLE
Add font size controls for graph annotations

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -89,6 +89,17 @@
                   <input id="cfgAxisY" type="text" value="y">
                 </label>
               </div>
+              <div class="settings-row">
+                <label>Skriftstørrelse tall på akser
+                  <input id="cfgFontTicks" type="number" min="6" max="72" step="1" value="16">
+                </label>
+                <label>Skriftstørrelse navn på akser
+                  <input id="cfgFontAxes" type="number" min="6" max="72" step="1" value="20">
+                </label>
+                <label>Skriftstørrelse navn på grafen
+                  <input id="cfgFontCurve" type="number" min="6" max="72" step="1" value="16">
+                </label>
+              </div>
             </fieldset>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add settings inputs so users can set font sizes for axis numbers, axis names, and graph labels
- store and clamp the configured font sizes via URL parameters and defaults for consistent reloads
- apply the chosen font sizes to axis ticks, axis labels, and curve name rendering on the board

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cc175cba1083249ab71815b1c12097