### PR TITLE
Add curve label visibility toggles to graftegner

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -79,6 +79,8 @@
               <div class="checkbox-row"><input id="cfgLock" type="checkbox" checked><label for="cfgLock">Lås forhold 1:1 (krever screen)</label></div>
               <div class="checkbox-row"><input id="cfgPan" type="checkbox"><label for="cfgPan">Tillat pan</label></div>
               <div class="checkbox-row"><input id="cfgSnap" type="checkbox" checked><label for="cfgSnap">Snap til rutenett</label></div>
+              <div class="checkbox-row"><input id="cfgShowCurveName" type="checkbox" checked><label for="cfgShowCurveName">Vis navn på grafen</label></div>
+              <div class="checkbox-row"><input id="cfgShowCurveExpr" type="checkbox"><label for="cfgShowCurveExpr">Vis funksjonsuttrykk</label></div>
               <div class="checkbox-row"><input id="cfgQ1" type="checkbox"><label for="cfgQ1">Bare 1. kvadrant</label></div>
               <div class="settings-row axis-names">
                 <label>Navn på akser</label>


### PR DESCRIPTION
## Summary
- add UI checkboxes to control showing curve names and function expressions
- persist the new preferences via URL parameters and build curve labels accordingly

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc22f81bf48324a431f4d63dc49bdb