### PR TITLE
Add label visibility toggles to graftegner

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -80,6 +80,8 @@
               <div class="checkbox-row"><input id="cfgPan" type="checkbox"><label for="cfgPan">Tillat pan</label></div>
               <div class="checkbox-row"><input id="cfgSnap" type="checkbox" checked><label for="cfgSnap">Snap til rutenett</label></div>
               <div class="checkbox-row"><input id="cfgQ1" type="checkbox"><label for="cfgQ1">Bare 1. kvadrant</label></div>
+              <div class="checkbox-row"><input id="cfgShowNames" type="checkbox" checked><label for="cfgShowNames">Vis navn på grafer</label></div>
+              <div class="checkbox-row"><input id="cfgShowExpr" type="checkbox"><label for="cfgShowExpr">Vis funksjonsuttrykk</label></div>
               <div class="settings-row axis-names">
                 <label>Navn på akser</label>
                 <label class="axis-label">x:


### PR DESCRIPTION
## Summary
- add UI toggles for showing curve names and expressions in Graftegner and persist them via URL parameters
- build curve label text dynamically so graphs can display names, expressions, or both depending on the toggles

## Testing
- not run (manual testing recommended)


------
https://chatgpt.com/codex/tasks/task_e_68cc2ba5dc1c83249c6c40acecdabe26