### PR TITLE
Allow single-cell grids and edge-aligned splits in Arealmodell B

### DIFF
--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -76,19 +76,19 @@
           <div class="settings">
             <div class="row">
               <label>Lengde
-                <input id="length" type="number" value="17" min="2">
+                <input id="length" type="number" value="17" min="1">
               </label>
               <label>Startposisjon
-                <input id="lengthStart" type="number" value="3" min="1">
+                <input id="lengthStart" type="number" value="3" min="0">
               </label>
               <label class="chk"><input id="showLengthHandle" type="checkbox" checked> Vis håndtak</label>
             </div>
             <div class="row">
               <label>Høyde
-                <input id="height" type="number" value="16" min="2">
+                <input id="height" type="number" value="16" min="1">
               </label>
               <label>Startposisjon
-                <input id="heightStart" type="number" value="5" min="1">
+                <input id="heightStart" type="number" value="5" min="0">
               </label>
               <label class="chk"><input id="showHeightHandle" type="checkbox" checked> Vis håndtak</label>
             </div>

--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -34,8 +34,8 @@ const CFG = {
       horizontal: true
     },
     limits: {
-      minColsEachSide: 1,
-      minRowsEachSide: 1
+      minColsEachSide: 0,
+      minRowsEachSide: 0
     },
     // Håndtak (piler)
     handleIcons: {
@@ -134,8 +134,8 @@ function draw() {
   const ADV = CFG.ADV,
     SV = CFG.SIMPLE;
   const UNIT = +ADV.unit || 40;
-  const ROWS = Math.max(2, Math.round((_SV$height$cells = (_SV$height = SV.height) === null || _SV$height === void 0 ? void 0 : _SV$height.cells) !== null && _SV$height$cells !== void 0 ? _SV$height$cells : 16));
-  const COLS = Math.max(2, Math.round((_SV$length$cells = (_SV$length = SV.length) === null || _SV$length === void 0 ? void 0 : _SV$length.cells) !== null && _SV$length$cells !== void 0 ? _SV$length$cells : 17));
+  const ROWS = Math.max(1, Math.round((_SV$height$cells = (_SV$height = SV.height) === null || _SV$height === void 0 ? void 0 : _SV$height.cells) !== null && _SV$height$cells !== void 0 ? _SV$height$cells : 16));
+  const COLS = Math.max(1, Math.round((_SV$length$cells = (_SV$length = SV.length) === null || _SV$length === void 0 ? void 0 : _SV$length.cells) !== null && _SV$length$cells !== void 0 ? _SV$length$cells : 17));
   const TEN = Math.max(1, Math.round((_ADV$check$ten = (_ADV$check = ADV.check) === null || _ADV$check === void 0 ? void 0 : _ADV$check.ten) !== null && _ADV$check$ten !== void 0 ? _ADV$check$ten : 10));
 
   // spacing for kant-tekst utenfor
@@ -167,15 +167,17 @@ function draw() {
   };
   const showGrid = ADV.grid !== false;
   const clickToMove = ADV.clickToMove !== false;
-  const showHeightAxis = ((_SV$height2 = SV.height) === null || _SV$height2 === void 0 ? void 0 : _SV$height2.show) !== false;
-  const showLengthAxis = ((_SV$length2 = SV.length) === null || _SV$length2 === void 0 ? void 0 : _SV$length2.show) !== false;
+  const showHeightAxis = ROWS > 1 && ((_SV$height2 = SV.height) === null || _SV$height2 === void 0 ? void 0 : _SV$height2.show) !== false;
+  const showLengthAxis = COLS > 1 && ((_SV$length2 = SV.length) === null || _SV$length2 === void 0 ? void 0 : _SV$length2.show) !== false;
   const dragVertical = showHeightAxis && ((_ADV$drag = ADV.drag) === null || _ADV$drag === void 0 ? void 0 : _ADV$drag.vertical) !== false;
   const dragHorizontal = showLengthAxis && ((_ADV$drag2 = ADV.drag) === null || _ADV$drag2 === void 0 ? void 0 : _ADV$drag2.horizontal) !== false;
   const splitLinesOn = ADV.splitLines !== false;
   const showHLine = splitLinesOn && showHeightAxis;
   const showVLine = splitLinesOn && showLengthAxis;
-  const minColsEachSide = Math.max(1, (_ADV$limits$minColsEa = (_ADV$limits = ADV.limits) === null || _ADV$limits === void 0 ? void 0 : _ADV$limits.minColsEachSide) !== null && _ADV$limits$minColsEa !== void 0 ? _ADV$limits$minColsEa : 1);
-  const minRowsEachSide = Math.max(1, (_ADV$limits$minRowsEa = (_ADV$limits2 = ADV.limits) === null || _ADV$limits2 === void 0 ? void 0 : _ADV$limits2.minRowsEachSide) !== null && _ADV$limits$minRowsEa !== void 0 ? _ADV$limits$minRowsEa : 1);
+  const rawMinColsEachSide = (_ADV$limits$minColsEa = (_ADV$limits = ADV.limits) === null || _ADV$limits === void 0 ? void 0 : _ADV$limits.minColsEachSide) !== null && _ADV$limits$minColsEa !== void 0 ? _ADV$limits$minColsEa : 0;
+  const rawMinRowsEachSide = (_ADV$limits$minRowsEa = (_ADV$limits2 = ADV.limits) === null || _ADV$limits2 === void 0 ? void 0 : _ADV$limits2.minRowsEachSide) !== null && _ADV$limits$minRowsEa !== void 0 ? _ADV$limits$minRowsEa : 0;
+  const minColsEachSide = Math.max(0, Math.min(Math.floor(COLS / 2), Math.round(rawMinColsEachSide) || 0));
+  const minRowsEachSide = Math.max(0, Math.min(Math.floor(ROWS / 2), Math.round(rawMinRowsEachSide) || 0));
   const initLeftCols = (_SV$length$handle = (_SV$length3 = SV.length) === null || _SV$length3 === void 0 ? void 0 : _SV$length3.handle) !== null && _SV$length$handle !== void 0 ? _SV$length$handle : Math.floor(COLS / 2);
   const initBottomRows = (_SV$height$handle = (_SV$height3 = SV.height) === null || _SV$height3 === void 0 ? void 0 : _SV$height3.handle) !== null && _SV$height$handle !== void 0 ? _SV$height$handle : Math.floor(ROWS / 2);
   const showLeftHandle = showHeightAxis && ((_SV$height4 = SV.height) === null || _SV$height4 === void 0 ? void 0 : _SV$height4.showHandle) !== false;
@@ -191,16 +193,20 @@ function draw() {
   const clamp = (v, a, b) => Math.max(a, Math.min(b, v));
   const clampInt = (v, a, b) => Math.max(a, Math.min(b, Math.round(v)));
   const snap = v => Math.round(v / UNIT) * UNIT;
-  const minX = ML + minColsEachSide * UNIT;
-  const maxX = ML + W - minColsEachSide * UNIT;
-  const minY = MT + minRowsEachSide * UNIT;
-  const maxY = MT + H - minRowsEachSide * UNIT;
+  const minSX = minColsEachSide * UNIT;
+  const maxSX = (COLS - minColsEachSide) * UNIT;
+  const minSY = minRowsEachSide * UNIT;
+  const maxSY = (ROWS - minRowsEachSide) * UNIT;
+  const minX = ML + minSX;
+  const maxX = ML + maxSX;
+  const minY = MT + minSY;
+  const maxY = MT + maxSY;
   const H_ICON_URL = (_ADV$handleIcons$hori = (_ADV$handleIcons2 = ADV.handleIcons) === null || _ADV$handleIcons2 === void 0 ? void 0 : _ADV$handleIcons2.horiz) !== null && _ADV$handleIcons$hori !== void 0 ? _ADV$handleIcons$hori : "";
   const V_ICON_URL = (_ADV$handleIcons$vert = (_ADV$handleIcons3 = ADV.handleIcons) === null || _ADV$handleIcons3 === void 0 ? void 0 : _ADV$handleIcons3.vert) !== null && _ADV$handleIcons$vert !== void 0 ? _ADV$handleIcons$vert : "";
 
   // state
-  let sx = clampInt(initLeftCols, 1, COLS - 1) * UNIT;
-  let sy = clampInt(initBottomRows, 1, ROWS - 1) * UNIT;
+  let sx = clampInt(initLeftCols, minColsEachSide, COLS - minColsEachSide) * UNIT;
+  let sy = clampInt(initBottomRows, minRowsEachSide, ROWS - minRowsEachSide) * UNIT;
   let lastSyncedLeft = null;
   let lastSyncedBottom = null;
   function syncSimpleHandles() {
@@ -415,6 +421,8 @@ function draw() {
     });
   }
   function redraw() {
+    sx = clamp(sx, minSX, maxSX);
+    sy = clamp(sy, minSY, maxSY);
     const wL = Math.round(sx / UNIT),
       wR = COLS - wL;
     const hB = Math.round(sy / UNIT),


### PR DESCRIPTION
## Summary
- allow split handles to collapse cells completely by default with zero minimum limits and tighter clamping
- auto-hide axes when a dimension has only one cell while keeping exported output in sync
- relax length/height inputs so single-cell grids and zero start offsets are easy to configure

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc55f2ed1c83248eb92fd39c25c846