### PR TITLE
Update Tenkeblokker menu icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,11 +196,9 @@
       </li>
       <li>
         <a href="tenkeblokker.html" target="content" title="Tenkeblokker" aria-label="Tenkeblokker">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" d="M4 7h16M4 7v4M20 7v4" />
-            <rect x="5" y="11" width="4" height="4" fill="currentColor" stroke="none" />
-            <rect x="10" y="11" width="4" height="4" fill="currentColor" stroke="none" />
-            <rect x="15" y="11" width="4" height="4" fill="currentColor" stroke="none" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 40" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <line x1="0" y1="5" x2="100" y2="5" stroke-linecap="round" />
+            <rect x="0" y="10" width="100" height="25" fill="currentColor" stroke="none" />
           </svg>
           <span class="sr-only">Tenkeblokker</span>
         </a>


### PR DESCRIPTION
## Summary
- redesign the Tenkeblokker navigation icon to display a single 100×25 rectangle
- add a 100-unit line segment positioned 5 units above the rectangle within the SVG viewbox

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ccf7f007cc8324880d029f10a913e2