### PR TITLE
Standardize settings form styling

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -82,12 +82,8 @@
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
     .btn:active{transform:translateY(1px)}
-    .card>fieldset{display:flex;flex-direction:column;gap:8px;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;}
     .figureSettings{display:grid;gap:var(--gap);grid-template-columns:repeat(var(--figure-settings-cols,1),minmax(0,1fr));align-items:stretch;}
-    .figureSettings fieldset{display:flex;flex-direction:column;gap:8px;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;min-width:0;}
-    legend{font-weight:600;font-size:13px;color:#374151;padding:0 4px;}
-    .settings label{display:flex;flex-direction:column;font-size:13px;color:#4b5563;}
-    .settings input,.settings select{padding:8px 10px;border:1px solid #d1d5db;border-radius:10px;font-size:14px;background:#fff;}
+    .figureSettings fieldset{min-width:0;}
     .checkbox-row{display:flex;align-items:center;gap:6px;}
     .colors{display:flex;flex-wrap:wrap;gap:6px;}
     .colors input{flex:0 0 40px;width:40px;height:40px;}

--- a/figurtall.html
+++ b/figurtall.html
@@ -60,15 +60,10 @@
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s;}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06);}
     .btn:active{transform:translateY(1px);}
-    .card>fieldset{display:flex;flex-direction:column;gap:8px;border:1px solid #e5e7eb;border-radius:10px;padding:10px;margin:0;}
-    .card--settings fieldset label{display:flex;align-items:center;gap:8px;font-size:14px;color:#374151;}
     .card--settings fieldset .fieldLabel{flex-direction:column;align-items:center;gap:6px;text-align:center;}
     .card--settings fieldset .fieldLabel span{display:block;}
     .card--settings fieldset .fieldLabel .stepper{margin:0;}
-    .card--settings fieldset .toggleLabel{align-items:center;}
     .card--settings fieldset .toggleLabel input{margin:0;}
-    .card--settings fieldset select{width:100%;padding:8px 10px;border:1px solid #d1d5db;border-radius:8px;font-size:14px;box-sizing:border-box;background:#fff;}
-    legend{font-weight:600;font-size:13px;color:#374151;padding:0 4px;}
     .card input[type="color"]{width:40px;height:40px;padding:0;border:none;}
     .colors{display:flex;flex-wrap:wrap;gap:6px;}
     .colors input{flex:0 0 40px;width:40px;height:40px;}

--- a/split.css
+++ b/split.css
@@ -28,3 +28,73 @@
     display: none;
   }
 }
+
+/* Shared styling for settings panels */
+.card--settings fieldset,
+.card[data-card="settings"] fieldset {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 12px;
+  margin: 0;
+}
+
+.card--settings legend,
+.card[data-card="settings"] legend {
+  font-weight: 600;
+  font-size: 13px;
+  color: #374151;
+  padding: 0 4px;
+}
+
+.card--settings label,
+.card[data-card="settings"] label {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: #4b5563;
+}
+
+.card--settings label.checkbox,
+.card--settings label.chk,
+.card--settings label.toggleLabel,
+.card[data-card="settings"] label.checkbox,
+.card[data-card="settings"] label.chk,
+.card[data-card="settings"] label.toggleLabel {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.card--settings input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),
+.card--settings select,
+.card--settings textarea,
+.card[data-card="settings"] input:not([type="checkbox"]):not([type="radio"]):not([type="range"]):not([type="color"]),
+.card[data-card="settings"] select,
+.card[data-card="settings"] textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 14px;
+  background: #fff;
+  color: #111827;
+  box-sizing: border-box;
+  font-family: inherit;
+  width: 100%;
+}
+
+.card--settings textarea,
+.card[data-card="settings"] textarea {
+  resize: vertical;
+  min-height: 72px;
+}
+
+.card--settings input[type="checkbox"],
+.card--settings input[type="radio"],
+.card[data-card="settings"] input[type="checkbox"],
+.card[data-card="settings"] input[type="radio"] {
+  accent-color: #3b82f6;
+}


### PR DESCRIPTION
## Summary
- add shared settings card styles to split.css so inputs, labels, and fieldsets look consistent across visualizations
- simplify figurtall and brøkfigurer CSS to rely on the shared styling while keeping their bespoke layout tweaks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd10f3ac50832497193ae230a920fa