### PR TITLE
Update figure settings layout and checkbox styling

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -105,9 +105,8 @@
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
     .btn:active{transform:translateY(1px)}
-    .figureSettings{display:grid;gap:var(--gap);grid-template-columns:repeat(var(--figure-settings-cols,1),minmax(0,1fr));align-items:stretch;}
+    .figureSettings{display:grid;gap:var(--gap);grid-template-columns:repeat(auto-fit,minmax(220px,1fr));align-items:stretch;}
     .figureSettings fieldset{min-width:0;}
-    .checkbox-row{display:flex;align-items:center;gap:6px;}
     .colors{display:flex;flex-wrap:wrap;gap:6px;}
     .colors input{flex:0 0 40px;width:40px;height:40px;}
     .box svg *:focus{outline:none;}
@@ -140,10 +139,7 @@
         <div class="card card--settings">
           <fieldset>
             <legend>Farger</legend>
-            <div class="checkbox-row">
-              <input id="allowWrong" type="checkbox" />
-              <label for="allowWrong">Tillat gale illustrasjoner</label>
-            </div>
+            <label class="checkbox"><input id="allowWrong" type="checkbox" /> <span>Tillat gale illustrasjoner</span></label>
             <label>Antall farger
               <input id="colorCount" type="number" min="1" max="6" value="1" />
             </label>

--- a/brøkfigurer.js
+++ b/brøkfigurer.js
@@ -379,7 +379,6 @@
       gridEl.dataset.rows = String(rows);
       gridEl.style.setProperty('--figure-rows', String(rows));
     }
-    if (settingsContainer) settingsContainer.style.setProperty('--figure-settings-cols', String(cols));
     if (addRowBtn) addRowBtn.style.display = rows >= MAX_ROWS ? 'none' : '';
     if (removeRowBtn) removeRowBtn.style.display = rows <= MIN_DIMENSION ? 'none' : '';
     if (addColumnBtn) addColumnBtn.style.display = cols >= MAX_COLS ? 'none' : '';


### PR DESCRIPTION
## Summary
- switch the figure settings grid to use auto-fit columns like other tools
- update the allow wrong illustration toggle to use the shared checkbox label style

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd5b3062b0832495fc35adfbf45eb5