### PR TITLE
Improve splitter resize responsiveness

### DIFF
--- a/split.js
+++ b/split.js
@@ -14,26 +14,51 @@ document.addEventListener('DOMContentLoaded', () => {
     let startX = 0;
     let startWidth = 0;
     const minWidth = 200;
+    let scheduledResize = false;
+    const scheduleResize = () => {
+      if (scheduledResize) return;
+      scheduledResize = true;
+      requestAnimationFrame(() => {
+        scheduledResize = false;
+        window.dispatchEvent(new Event('resize'));
+      });
+    };
+
+    let gridWidth = 0;
     const onMove = e => {
       const dx = e.clientX - startX;
       let newWidth = startWidth - dx;
-      const maxWidth = grid.clientWidth - 100;
+      const maxWidth = Math.max(minWidth, gridWidth - 100);
       if (newWidth < minWidth) newWidth = minWidth;
       if (newWidth > maxWidth) newWidth = maxWidth;
       grid.style.setProperty('--side-width', `${newWidth}px`);
-      window.dispatchEvent(new Event('resize'));
+      scheduleResize();
     };
-    const stopDrag = () => {
+    const stopDrag = e => {
+      if (
+        e &&
+        typeof splitter.releasePointerCapture === 'function' &&
+        typeof splitter.hasPointerCapture === 'function' &&
+        splitter.hasPointerCapture(e.pointerId)
+      ) {
+        splitter.releasePointerCapture(e.pointerId);
+      }
       document.removeEventListener('pointermove', onMove);
       document.removeEventListener('pointerup', stopDrag);
+      scheduleResize();
     };
     const startDrag = e => {
       e.preventDefault();
       startX = e.clientX;
       startWidth = side.getBoundingClientRect().width;
+      gridWidth = grid.clientWidth;
+      if (typeof splitter.setPointerCapture === 'function') {
+        splitter.setPointerCapture(e.pointerId);
+      }
       document.addEventListener('pointermove', onMove);
       document.addEventListener('pointerup', stopDrag);
     };
     splitter.addEventListener('pointerdown', startDrag);
+    splitter.addEventListener('lostpointercapture', stopDrag);
   });
 });


### PR DESCRIPTION
## Summary
- throttle splitter-driven resize events so the graph board updates on animation frames instead of every pointer move
- reuse cached layout data and pointer capture to keep the drag interaction smooth on wide layouts

## Testing
- not run (frontend change only)


------
https://chatgpt.com/codex/tasks/task_e_68cd669ad08c8324980d0a7e359d5cfd