### PR TITLE
Adjust sign line zero placement and row label input

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -219,6 +219,12 @@
       flex: 1 1 160px;
       min-width: 120px;
     }
+    .rows-list .row-label {
+      flex: 0 0 auto;
+    }
+    .rows-list .row-label input {
+      width: 140px;
+    }
     .points-list .value-field {
       flex: 0 0 auto;
       min-width: 0;

--- a/fortegnsskjema.js
+++ b/fortegnsskjema.js
@@ -656,9 +656,10 @@
         cursor: 'ew-resize'
       });
       svg.append(vertical);
+      const labelY = point.type === 'pole' ? arrowY + 6 : baseRowY + 6;
       const label = createSvgElement('text', {
         x: px,
-        y: arrowY + 6,
+        y: labelY,
         'text-anchor': 'middle',
         'font-size': 16,
         'font-weight': 600,


### PR DESCRIPTION
## Summary
- move the visual "0" indicator from the x-axis down to the first sign line for clearer alignment with the fortegnslinje
- limit the width of the fortegnslinje name input so it renders as a compact text box instead of spanning the full row

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd6f28119883248b73620b7502ffd8