### PR TITLE
Remove default full-width styling for settings inputs

### DIFF
--- a/split.css
+++ b/split.css
@@ -85,7 +85,6 @@
   color: #111827;
   box-sizing: border-box;
   font-family: inherit;
-  width: 100%;
 }
 
 .card--settings textarea,


### PR DESCRIPTION
## Summary
- remove the default `width: 100%` setting on settings panel form controls so they no longer stretch across the container

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cd7f93ea9c83249172ff5fa37dbc46