### PR TITLE
Automate prikk-til-prikk fasit line generation

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -369,12 +369,7 @@
         </div>
         <div class="card card--lines">
           <h2>Streker</h2>
-          <fieldset id="lineModeFieldset">
-            <legend>Rediger streker</legend>
-            <label class="radio-option"><input type="radio" name="lineMode" value="answer" checked> Fasit</label>
-            <label class="radio-option"><input type="radio" name="lineMode" value="predefined"> Forhåndsdefinert</label>
-            <label class="radio-option"><input type="radio" name="lineMode" value="none"> Flytt punkter</label>
-          </fieldset>
+          <p class="hint">Fasit-strekene kobles automatisk sammen i punktrekkefølgen.</p>
           <div class="line-summary">
             <div>Fasit-streker: <span id="answerCount">0</span></div>
             <div>Forhåndsdefinerte streker: <span id="predefCount">0</span></div>


### PR DESCRIPTION
## Summary
- auto-generate fasit lines sequentially between real points and block connections to false points
- drop the line editing mode UI and update edit mode messaging for the automatic behaviour

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cdc0689d488324bdf349e95a6c8c52