### PR TITLE
Adjust fortegnsskjema spacing

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -110,7 +110,7 @@
       gap: 4px;
     }
     .chart-overlay__value input[type="number"] {
-      width: 3.2ch;
+      width: 4.2ch;
       min-width: 0;
     }
     .chart-overlay__value-input {

--- a/fortegnsskjema.js
+++ b/fortegnsskjema.js
@@ -728,7 +728,7 @@
     const domain = domainInfo.active;
     const width = svg.clientWidth || svg.parentElement.clientWidth || 900;
     const rowSpacing = 70;
-    const arrowY = 40;
+    const arrowY = 70;
     const marginLeft = 70;
     const marginRight = 40;
     const baseHeight = arrowY + 60 + Math.max(1, state.signRows.length) * rowSpacing + 60;


### PR DESCRIPTION
## Summary
- add more top spacing to the fortegnsskjema chart by lowering the axis position
- widen the overlay value input for improved readability

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ce92651490832481c59e2df77f282a