### PR TITLE
Add toggle for forced integer axis ticks

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -182,6 +182,14 @@
                         </label>
                       </td>
                     </tr>
+                    <tr>
+                      <td colspan="2">
+                        <label class="checkbox-inline">
+                          <input id="cfgForceTicks" type="checkbox" checked>
+                          <span>Tving 1, 2, 3 på akser</span>
+                        </label>
+                      </td>
+                    </tr>
                   </tbody>
                 </table>
                 <div class="axis-font-grid">


### PR DESCRIPTION
## Summary
- add a "Tving 1, 2, 3 på akser" checkbox in the settings panel and persist it via query parameters
- switch the board setup between custom 1-unit ticks and JSXGraph defaults based on the new toggle, auto-disabling it when more than 20 labels would appear on an axis
- keep the UI and board state in sync so the option is disabled with an explanatory tooltip when the span forces the fallback behaviour

## Testing
- npm test *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68cfb8668e5c8324a81458a12a1ecd5b