### PR TITLE
Adjust label spacing and stacking on prikk-til-prikk board

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -38,7 +38,7 @@
     .card--board { gap: 16px; }
     .figure {
       border-radius: 10px;
-      background: #f9fafb;
+      background: #fff;
       border: 1px solid #e5e7eb;
       overflow: hidden;
       position: relative;
@@ -48,7 +48,9 @@
       height: clamp(320px, 60vh, 520px);
       display: block;
       touch-action: none;
-      background: #fff;
+      position: relative;
+      z-index: 1;
+      background: transparent;
     }
     .toolbar {
       display: flex;
@@ -295,6 +297,7 @@
       pointer-events: none;
       font-size: 14px;
       line-height: 1.4;
+      z-index: 0;
     }
     .board-label {
       position: absolute;

--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -2,8 +2,8 @@
   const SVG_NS = 'http://www.w3.org/2000/svg';
   const BOARD_WIDTH = 1000;
   const BOARD_HEIGHT = 700;
-  const LABEL_OFFSET_X = 16;
-  const LABEL_OFFSET_Y = -14;
+  const LABEL_OFFSET_X = 24;
+  const LABEL_OFFSET_Y = -20;
   const POINT_RADIUS = 11;
   const DEFAULT_LABEL_FONT_SIZE = 14;
   const MIN_LABEL_FONT_SIZE = 10;


### PR DESCRIPTION
## Summary
- increase the default label offset so labels sit farther away from their points
- ensure the SVG board renders above the HTML label layer so dots are never hidden

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cfe172488c8324ab3b3c6237e75b0c