### PR TITLE
Fix Arealmodell handles hiding at corners

### DIFF
--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -1008,8 +1008,8 @@ function draw() {
       hDownCY = MT + H;
     const cornerCX = ML + W,
       cornerCY = MT;
-    const handleLeftVisible = showLeftHandle && hasHorizontalDivision;
-    const handleDownVisible = showBottomHandle && hasVerticalDivision;
+    const handleLeftVisible = showLeftHandle;
+    const handleDownVisible = showBottomHandle;
     const handleCornerVisible = showTotalHandle;
     if (handleLeft) {
       set(handleLeft, "x", hLeftCX - HANDLE_SIZE / 2);


### PR DESCRIPTION
## Summary
- keep the length and height handles visible in the 4-rectangle layout even when moved to the outer corner

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cff19902ac8324bc58cd09ec51e3b7