### PR TITLE
Remove layer gap control from Kvikkbilder blocks

### DIFF
--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -180,11 +180,6 @@
                 <input id="cfg-dybde" type="number" min="1" value="2">
               </label>
             </div>
-            <div class="field-row field-row--two">
-              <label>Lagavstand i hver figur
-                <input id="cfg-klosser-layerGap" type="number" min="0" value="6">
-              </label>
-            </div>
           </div>
           <div id="monsterConfig">
             <div class="field-row field-row--two">

--- a/kvikkbilder.js
+++ b/kvikkbilder.js
@@ -8,7 +8,6 @@
   const cfgBredde = document.getElementById('cfg-bredde');
   const cfgHoyde = document.getElementById('cfg-hoyde');
   const cfgDybde = document.getElementById('cfg-dybde');
-  const cfgKlosserLayerGap = document.getElementById('cfg-klosser-layerGap');
   const cfgVisibility = document.getElementById('cfg-visibility');
   const cfgShowExpression = document.getElementById('cfg-show-expression');
   const cfgMonsterAntallX = document.getElementById('cfg-monster-antallX');
@@ -344,9 +343,6 @@
     const defaultLayerGap = Number.isFinite(DEFAULT_CFG.klosser.layerGap) ? DEFAULT_CFG.klosser.layerGap : 0;
     const layerGap = Number.isFinite(CFG.klosser.layerGap) ? Math.max(0, CFG.klosser.layerGap) : defaultLayerGap;
     CFG.klosser.layerGap = layerGap;
-    if (cfgKlosserLayerGap) {
-      cfgKlosserLayerGap.value = String(layerGap);
-    }
     const perFig = width * height * depth;
     const total = cols * rows * perFig;
     const firstExpression = formatOuterInnerExpression([cols, rows], [width, height, depth]);
@@ -891,7 +887,6 @@
     if (cfgBredde) cfgBredde.value = CFG.klosser.bredde;
     if (cfgHoyde) cfgHoyde.value = CFG.klosser.hoyde;
     if (cfgDybde) cfgDybde.value = CFG.klosser.dybde;
-    if (cfgKlosserLayerGap) cfgKlosserLayerGap.value = CFG.klosser.layerGap;
     if (cfgMonsterAntallX) cfgMonsterAntallX.value = CFG.monster.antallX;
     if (cfgMonsterAntallY) cfgMonsterAntallY.value = CFG.monster.antallY;
     if (cfgAntall) cfgAntall.value = CFG.monster.antall;
@@ -988,7 +983,6 @@
   bindNumberInput(cfgBredde, () => CFG.klosser, 'bredde', 1);
   bindNumberInput(cfgHoyde, () => CFG.klosser, 'hoyde', 1);
   bindNumberInput(cfgDybde, () => CFG.klosser, 'dybde', 1);
-  bindFloatInput(cfgKlosserLayerGap, () => CFG.klosser, 'layerGap', 0, DEFAULT_CFG.klosser.layerGap);
   bindNumberInput(cfgMonsterAntallX, () => CFG.monster, 'antallX', 0);
   bindNumberInput(cfgMonsterAntallY, () => CFG.monster, 'antallY', 0);
   bindNumberInput(cfgAntall, () => CFG.monster, 'antall', 0);


### PR DESCRIPTION
## Summary
- remove the "Lagavstand i hver figur" input from the Kvikkbilder klosser settings
- rely on the existing configuration defaults to keep the layer gap value at 6 without UI bindings

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cff494aaf8832487a1a1ecd2b998aa