### PR TITLE
Increase left margin for area model labels

### DIFF
--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -33,7 +33,7 @@ const CFG = {
     svgId: "area",
     unit: 40,
     margins: {
-      l: 80,
+      l: 110,
       r: 40,
       t: 40,
       b: 120


### PR DESCRIPTION
## Summary
- expand the default left margin for the arealmodell diagram so edge labels have extra space

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cffc5911ac83248434a52a1c3cd6ad