### PR TITLE
Render function labels with KaTeX

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -6,6 +6,7 @@
   <title>Graftegner</title>
 
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" />
 
   <style>
     :root { --gap: 18px; }
@@ -230,6 +231,7 @@
   </div>
 
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
   <script defer src="graftegner.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>


### PR DESCRIPTION
## Summary
- load KaTeX assets in the graph drawer so math expressions can be typeset
- convert curve labels to KaTeX-rendered HTML with fallbacks and updated measurement logic

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d05af8d8008324805eaec39a9309ee