### PR TITLE
Update fortegnsskjema nav icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -289,10 +289,10 @@
       </li>
       <li>
         <a href="fortegnsskjema.html" target="content" title="Fortegnsskjema – under utvikling" aria-label="Fortegnsskjema, under utvikling">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h13.5m0 0 2.5-2.5M17.5 6l2.5 2.5" />
-            <path stroke-linecap="round" stroke-linejoin="round" d="M4 12h14" />
-            <path stroke-linecap="round" stroke-linejoin="round" d="M4 18h7" stroke-dasharray="3 2" />
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.2" aria-hidden="true">
+            <path stroke-linecap="round" stroke-linejoin="round" d="M20 7H8M8 7l3-3M8 7l3 3" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 14h14" stroke-dasharray="2.2 2.2" />
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 18h10" />
           </svg>
           <span class="sr-only">Fortegnsskjema</span>
           <span class="nav-badge" aria-hidden="true">Beta</span>


### PR DESCRIPTION
## Summary
- redesign the Fortegnsskjema navigation icon with a left-pointing axis arrow
- add two thinner lines beneath the arrow, one dashed and one solid, to mirror the sign chart layout

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d0644c468c832486dec5beab2601e4