### PR TITLE
Add example description field to all visualizations

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -73,6 +73,10 @@
       </div>
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -60,6 +60,10 @@
       </div>
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -79,6 +79,10 @@
       </div>
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -132,6 +132,10 @@
       </div>
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -189,6 +189,10 @@
 
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -217,6 +217,10 @@
 
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -31,6 +31,10 @@
 
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/examples-viewer.js
+++ b/examples-viewer.js
@@ -171,6 +171,14 @@ function renderExamples() {
     arr.forEach((ex, idx) => {
       const wrap = document.createElement('div');
       wrap.className = 'example';
+      if (ex && typeof ex.description === 'string' && ex.description.trim()) {
+        const description = document.createElement('p');
+        description.className = 'example-description';
+        description.textContent = ex.description;
+        description.style.whiteSpace = 'pre-wrap';
+        description.style.margin = '0 0 8px';
+        wrap.appendChild(description);
+      }
       const iframe = document.createElement('iframe');
       iframe.setAttribute('loading', 'lazy');
       iframe.title = `Eksempel ${idx + 1} – ${path}`;

--- a/examples.js
+++ b/examples.js
@@ -235,6 +235,27 @@
   let currentExampleIndex = null;
   let tabsContainer = null;
   let tabButtons = [];
+  let descriptionInput = null;
+  function getDescriptionInput() {
+    if (descriptionInput && descriptionInput.isConnected) return descriptionInput;
+    descriptionInput = document.getElementById('exampleDescription');
+    return descriptionInput || null;
+  }
+  function getDescriptionValue() {
+    const input = getDescriptionInput();
+    if (!input) return '';
+    const value = input.value;
+    return typeof value === 'string' ? value : '';
+  }
+  function setDescriptionValue(value) {
+    const input = getDescriptionInput();
+    if (!input) return;
+    if (typeof value === 'string') {
+      input.value = value;
+    } else {
+      input.value = '';
+    }
+  }
   let defaultEnsureScheduled = false;
   let tabsHostCard = null;
   const hasUrlOverrides = (() => {
@@ -682,13 +703,18 @@
     }
     return {
       config: cfg,
-      svg: svgMarkup
+      svg: svgMarkup,
+      description: getDescriptionValue()
     };
   }
   function loadExample(index) {
     const examples = getExamples();
     const ex = examples[index];
-    if (!ex || !ex.config) return false;
+    if (!ex || !ex.config) {
+      setDescriptionValue('');
+      return false;
+    }
+    setDescriptionValue(typeof ex.description === 'string' ? ex.description : '');
     const cfg = ex.config;
     let applied = false;
     for (const name of BINDING_NAMES) {

--- a/figurtall.html
+++ b/figurtall.html
@@ -150,6 +150,10 @@
       </div>
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -307,6 +307,10 @@
 
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/graftegner.html
+++ b/graftegner.html
@@ -112,6 +112,10 @@
 
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/kuler.html
+++ b/kuler.html
@@ -100,6 +100,10 @@
       </div>
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempler</button>
             <button id="btnDeleteExample" class="btn" type="button">Slette eksempler</button>

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -97,6 +97,10 @@
       </div>
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -129,6 +129,10 @@
       </div>
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/nkant.html
+++ b/nkant.html
@@ -49,6 +49,10 @@
 
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -70,6 +70,10 @@
 
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -405,6 +405,10 @@
       </div>
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/split.css
+++ b/split.css
@@ -93,6 +93,30 @@
   min-height: 72px;
 }
 
+.card--examples {
+  gap: 14px;
+}
+
+.card--examples .example-description {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: #4b5563;
+}
+
+.card--examples .example-description textarea {
+  border: 1px solid #d1d5db;
+  border-radius: 10px;
+  padding: 8px 10px;
+  font-size: 14px;
+  font-family: inherit;
+  color: #111827;
+  background: #fff;
+  resize: vertical;
+  min-height: 72px;
+}
+
 .card--settings input[type="checkbox"],
 .card--settings input[type="radio"],
 .card[data-card="settings"] input[type="checkbox"],

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -53,6 +53,10 @@
       </div>
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -187,6 +187,10 @@
       </div>
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>

--- a/trefigurer.html
+++ b/trefigurer.html
@@ -186,6 +186,10 @@
       </div>
       <div class="side">
         <div class="card card--examples">
+          <div class="example-description">
+            <label for="exampleDescription">Oppgavetekst</label>
+            <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
+          </div>
           <div class="toolbar">
             <button id="btnSaveExample" class="btn" type="button">Lagre eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Slett eksempel</button>


### PR DESCRIPTION
## Summary
- add a reusable oppgavetekst textarea above the save/delete example controls on every visualization
- persist the free-text description together with saved examples and surface it in the example viewer
- style the new textarea consistently via the shared split.css helpers

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68d1c2e70aec83248cf71e4c4e10b6d9