### PR TITLE
Adjust graph settings layout and auto point selection

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -57,9 +57,13 @@
     .func-fields--first .func-row{
       display:grid;
       gap:12px;
-      grid-template-columns:repeat(auto-fit,minmax(220px,1fr));
+      grid-template-columns:repeat(2,minmax(0,1fr));
       align-items:start;
     }
+    .func-fields--first .func-row label,
+    .func-group .func-fields label{ min-width:0; }
+    .func-row--main label,
+    .func-row--gliders label{ width:100%; }
     .func-fields--first .func-row label{ width:100%; }
     @media (max-width:680px){
       .function-controls{ align-items:stretch; }


### PR DESCRIPTION
## Summary
- align the first function and domain inputs on a single row with half-width fields for a tighter layout
- place the graph point count and start position controls side by side
- auto-lock the point count selector to 1 or 2 when the entered function matches linear forms with coefficients a/b while keeping start position editable

## Testing
- not run (project does not define automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d23659818083248ff53c8e6651cf81