### PR TITLE
Update global settings layout in Tenkeblokker

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -101,10 +101,7 @@
       width:100%;
     }
     .tb-settings fieldset.tb-settings-global{gap:10px;grid-column:1 / -1;}
-    .tb-settings fieldset.tb-settings-global .tb-row-label-inputs{display:grid;gap:8px;}
-    .tb-settings fieldset.tb-settings-global .tb-row-label-inputs[data-columns="1"]{grid-template-columns:repeat(1,minmax(0,1fr));}
-    .tb-settings fieldset.tb-settings-global .tb-row-label-inputs[data-columns="2"]{grid-template-columns:repeat(2,minmax(0,1fr));}
-    .tb-settings fieldset.tb-settings-global .tb-row-label-inputs[data-columns="3"]{grid-template-columns:repeat(3,minmax(0,1fr));}
+    .tb-settings fieldset.tb-settings-global .tb-row-label-inputs{display:flex;flex-direction:column;gap:8px;}
     .tb-settings fieldset.tb-settings-global .checkbox-row.is-disabled{opacity:.6;}
     .addFigureBtn{
       width:clamp(30px,7.5vw,60px);

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -664,19 +664,12 @@ function buildGlobalSettings(targetFragment) {
   if (rowCount > 0) {
     const labelWrapper = document.createElement('div');
     labelWrapper.className = 'tb-row-label-inputs';
-    let columns = 1;
-    if (rowCount >= 4) {
-      columns = 3;
-    } else if (rowCount >= 2) {
-      columns = 2;
-    }
-    labelWrapper.dataset.columns = String(columns);
     for (let i = 0; i < rowCount; i++) {
       const rowLabel = document.createElement('label');
-      rowLabel.textContent = `Rad ${i + 1}`;
       const input = document.createElement('input');
       input.type = 'text';
       input.placeholder = 'Tekst foran rad';
+      input.setAttribute('aria-label', `Tekst foran rad ${i + 1}`);
       const existingValue = Array.isArray(CONFIG.rowLabels) && typeof CONFIG.rowLabels[i] === 'string' ? CONFIG.rowLabels[i] : '';
       input.value = existingValue;
       input.addEventListener('input', () => {


### PR DESCRIPTION
## Summary
- remove the visible "Rad" labels from the global row label inputs while keeping their placeholders
- stack the global row label inputs vertically for a more intuitive layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d237f0c86c8324877d459917345f44