### PR TITLE
Apply shared base styling to visualizations

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Arealmodell</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; }
     html,body { height: 100%; }
@@ -74,7 +75,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Arealmodell A</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <link rel="stylesheet" href="base.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css" />
   <style>
     :root { --gap: 18px; }
@@ -61,7 +62,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Arealmodell B</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; }
     html,body { height: 100%; }
@@ -80,7 +81,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/base.css
+++ b/base.css
@@ -1,0 +1,213 @@
+:root {
+  --gap: 18px;
+  --surface-bg: #f7f8fb;
+  --text-color: #111827;
+  --heading-color: #374151;
+  --label-color: #4b5563;
+  --muted-color: #6b7280;
+  --card-border: #e5e7eb;
+  --card-radius: 14px;
+  --control-radius: 10px;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
+  color: var(--text-color);
+  background: var(--surface-bg);
+  padding: 20px;
+}
+
+.wrap {
+  max-width: 1200px;
+  margin: 0 auto;
+}
+
+.grid {
+  display: grid;
+  gap: var(--gap);
+  align-items: start;
+}
+
+.side {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap);
+}
+
+.card {
+  background: #fff;
+  border: 1px solid var(--card-border);
+  border-radius: var(--card-radius);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.04);
+  padding: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.card h2 {
+  margin: 0 0 6px 2px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--heading-color);
+}
+
+.figure {
+  border-radius: 10px;
+  background: #fafbfc;
+  overflow: hidden;
+  border: 1px solid #eef0f3;
+}
+
+.figure svg {
+  display: block;
+  width: 100%;
+  height: auto;
+}
+
+.toolbar {
+  display: flex;
+  gap: 10px;
+  justify-content: flex-start;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
+.btn {
+  appearance: none;
+  border: 1px solid #d1d5db;
+  background: #fff;
+  border-radius: var(--control-radius);
+  padding: 8px 12px;
+  font-size: 14px;
+  cursor: pointer;
+  transition: box-shadow 0.2s, transform 0.02s;
+  font-family: inherit;
+  color: inherit;
+}
+
+.btn:hover {
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+}
+
+.btn:active {
+  transform: translateY(1px);
+}
+
+label {
+  font-size: 13px;
+  color: var(--label-color);
+}
+
+textarea,
+select,
+input[type="text"],
+input[type="number"],
+input[type="email"],
+input[type="password"],
+input[type="search"],
+input[type="url"],
+input[type="tel"],
+input[type="color"],
+input[type="date"],
+input[type="time"],
+input[type="datetime-local"],
+input[type="month"] {
+  border: 1px solid #d1d5db;
+  border-radius: var(--control-radius);
+  padding: 8px 10px;
+  font-size: 14px;
+  background: #fff;
+  color: var(--text-color);
+  box-sizing: border-box;
+  font-family: inherit;
+}
+
+textarea {
+  width: 100%;
+  resize: vertical;
+  min-height: 72px;
+}
+
+select {
+  background-color: #fff;
+}
+
+input:disabled,
+textarea:disabled,
+select:disabled {
+  background: #f3f4f6;
+  color: #9ca3af;
+  cursor: not-allowed;
+}
+
+.small {
+  font-size: 12px;
+  color: var(--muted-color);
+}
+
+.sep {
+  height: 1px;
+  background: #eef0f3;
+  margin: 8px 0;
+}
+
+.card--examples {
+  gap: 14px;
+}
+
+.card--examples .example-description {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+  color: var(--label-color);
+}
+
+.form-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+}
+
+@media (max-width: 600px) {
+  .form-row {
+    grid-template-columns: 1fr;
+  }
+}
+
+.grid-3 {
+  display: grid;
+  grid-template-columns: 24px max-content 44px;
+  gap: 4px;
+  align-items: center;
+}
+
+.legend {
+  font-weight: 600;
+  font-size: 13px;
+  color: var(--heading-color);
+  margin-top: 8px;
+}
+
+.radio-row {
+  display: flex;
+  gap: 14px;
+  align-items: center;
+}
+
+.tight {
+  padding: 4px 8px;
+  width: 44px;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  accent-color: #3b82f6;
+}

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Brøkfigurer</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <link rel="stylesheet" href="base.css" />
   <!-- JSXGraph -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css">
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
@@ -133,7 +134,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Brøksirkler</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <link rel="stylesheet" href="base.css" />
 
   <style>
     :root { --purple:#5B2AA5; --rim:#333; --dash:#000; --gap:18px; }
@@ -190,7 +191,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Brøkvegg</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; --purple:#5B2AA5; }
     html, body { height: 100%; }
@@ -218,7 +219,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -5,12 +5,13 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Interaktivt stolpediagram (UU)</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
-    <link rel="stylesheet" href="../diagram.css" />
+  <link rel="stylesheet" href="../base.css" />
+  <link rel="stylesheet" href="../diagram.css" />
 
   <style>
     svg { touch-action: none; }
   </style>
-    <link rel="stylesheet" href="../split.css" />
+  <link rel="stylesheet" href="../split.css" />
 
 </head>
 <body>
@@ -32,7 +33,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/figurtall.html
+++ b/figurtall.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Figurtall</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap:18px; --card-min:240px; }
     html,body{height:100%;}
@@ -151,7 +152,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Fortegnsskjema</title>
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; }
     html, body { height: 100%; }
@@ -308,7 +309,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/graftegner.html
+++ b/graftegner.html
@@ -8,6 +8,7 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" />
 
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; }
     html,body { height: 100%; }
@@ -113,7 +114,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/kuler.html
+++ b/kuler.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Kuler</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap:18px; }
     html,body{height:100%;}
@@ -101,7 +102,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Numbervisuals</title>
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; }
     html,body{height:100%;}
@@ -98,7 +99,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Kvikkbilder</title>
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; }
     html,body{height:100%;}
@@ -130,7 +131,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/nkant.html
+++ b/nkant.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Nkant – én SVG med flere figurer</title>
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; }
     html,body { height: 100%; }
@@ -50,7 +51,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Perlesnor</title>
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; }
     html, body { height: 100%; }
@@ -71,7 +72,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Prikk til prikk (beta)</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" />
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; }
     html, body { height: 100%; }
@@ -406,7 +407,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Tenkeblokker</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap:18px; }
     html,body{height:100%;}
@@ -54,7 +55,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Tenkeblokker</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root {
       --gap: 18px;
@@ -188,7 +189,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">

--- a/trefigurer.html
+++ b/trefigurer.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Trefigurer</title>
+  <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; }
     html, body { height: 100%; }
@@ -187,7 +188,7 @@
       <div class="side">
         <div class="card card--examples">
           <div class="example-description">
-            <label for="exampleDescription">Oppgavetekst</label>
+            <label for="exampleDescription">Oppgavetekst (valgfritt)</label>
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">


### PR DESCRIPTION
## Summary
- add a shared `base.css` that captures the rounded nKant visual style for cards, buttons, and form controls
- load the shared stylesheet across all visualization pages and rename the example description label to "Oppgavetekst (valgfritt)"

## Testing
- not run (project has no automated tests)


------
https://chatgpt.com/codex/tasks/task_e_68d237032a0083248140499067921cbd