### PR TITLE
Add live KaTeX preview for graph function inputs

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -51,6 +51,26 @@
       gap:6px;
       width:100%;
     }
+    .func-input .func-preview{
+      display:none;
+      margin-top:2px;
+      padding:6px 8px;
+      border-radius:8px;
+      border:1px solid #e5e7eb;
+      background:#f9fafb;
+      font-size:14px;
+      line-height:1.4;
+      color:#111827;
+      word-break:break-word;
+      overflow-x:auto;
+    }
+    .func-preview--latex{
+      font-size:16px;
+      font-family:"KaTeX_Main","Times New Roman",Times,serif;
+    }
+    .func-preview--text{
+      font-family:inherit;
+    }
     .func-fields--first{
       grid-template-columns:1fr;
       gap:16px;

--- a/graftegner.js
+++ b/graftegner.js
@@ -2514,6 +2514,42 @@ function setupSettingsForm() {
   if (snapCheckbox) {
     snapCheckbox.checked = ADV.points.snap.enabled;
   }
+  const updateFunctionPreview = input => {
+    if (!input) return;
+    const host = input.closest('.func-input');
+    if (!host) return;
+    const preview = host.querySelector('[data-preview]');
+    if (!preview) return;
+    const raw = input.value != null ? String(input.value) : '';
+    const latex = convertExpressionToLatex(raw);
+    const html = latex ? renderLatexToHtml(latex) : '';
+    const plain = normalizeExpressionText(raw);
+    preview.innerHTML = '';
+    preview.textContent = '';
+    preview.classList.remove('func-preview--latex', 'func-preview--text', 'func-preview--empty');
+    if (html) {
+      preview.innerHTML = html;
+      preview.style.display = 'block';
+      preview.classList.add('func-preview--latex');
+      preview.setAttribute('data-mode', 'latex');
+      return;
+    }
+    if (plain) {
+      preview.textContent = plain;
+      preview.style.display = 'block';
+      preview.classList.add('func-preview--text');
+      preview.setAttribute('data-mode', 'text');
+      return;
+    }
+    preview.style.display = 'none';
+    preview.classList.add('func-preview--empty');
+    preview.setAttribute('data-mode', 'empty');
+  };
+  const updateAllFunctionPreviews = () => {
+    if (!funcRows) return;
+    const inputs = funcRows.querySelectorAll('input[data-fun]');
+    inputs.forEach(input => updateFunctionPreview(input));
+  };
   const updateStartInputState = () => {
     if (!gliderStartInput) return;
     const active = shouldEnableGliders();
@@ -2655,6 +2691,7 @@ function setupSettingsForm() {
             <label class="func-input">
               <span>${titleLabel}</span>
               <input type="text" data-fun>
+              <div class="func-preview" data-preview aria-hidden="true"></div>
             </label>
             <label class="domain">
               <span>Avgrensning</span>
@@ -2684,6 +2721,7 @@ function setupSettingsForm() {
           <label class="func-input">
             <span>${titleLabel}</span>
             <input type="text" data-fun>
+            <div class="func-preview" data-preview aria-hidden="true"></div>
           </label>
           <label class="domain">
             <span>Avgrensning</span>
@@ -2702,6 +2740,7 @@ function setupSettingsForm() {
       funInput.addEventListener('input', () => {
         toggleDomain(funInput);
         syncSimpleFromForm();
+        updateFunctionPreview(funInput);
       });
     }
     if (domInput) {
@@ -2726,6 +2765,7 @@ function setupSettingsForm() {
     }
     if (funInput) {
       toggleDomain(funInput);
+      updateFunctionPreview(funInput);
     }
     return row;
   };
@@ -2771,6 +2811,7 @@ function setupSettingsForm() {
       const startVals = Array.isArray((_SIMPLE_PARSED2 = SIMPLE_PARSED) === null || _SIMPLE_PARSED2 === void 0 ? void 0 : _SIMPLE_PARSED2.startX) ? SIMPLE_PARSED.startX.filter(Number.isFinite) : [];
       gliderStartInput.value = startVals.length ? startVals.map(formatNumber).join(', ') : '1';
     }
+    updateAllFunctionPreviews();
     updateGliderVisibility();
     syncSimpleFromForm();
     updateSnapAvailability();


### PR DESCRIPTION
## Summary
- add a styled KaTeX preview area under each function input
- render function expressions with KaTeX (falling back to text) while editing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d24c86990883249fa791565078108d