### PR TITLE
Add MathLive editor to graftegner

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -7,6 +7,7 @@
 
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mathlive/dist/mathlive-static.css" />
 
   <link rel="stylesheet" href="base.css" />
   <style>
@@ -50,6 +51,38 @@
       flex-direction:column;
       gap:6px;
       width:100%;
+    }
+    .func-input .func-editor{
+      display:flex;
+      flex-direction:column;
+      gap:4px;
+    }
+    .func-math-field{
+      display:block;
+      width:100%;
+      min-height:44px;
+      border:1px solid #d1d5db;
+      border-radius:10px;
+      padding:8px 10px;
+      font-size:15px;
+      line-height:1.4;
+      background:#fff;
+      box-sizing:border-box;
+      transition:border-color .15s ease, box-shadow .15s ease;
+    }
+    .func-math-field:focus{
+      outline:none;
+      border-color:#6366f1;
+      box-shadow:0 0 0 3px rgba(99,102,241,.15);
+    }
+    .func-math-field::part(container){
+      min-height:26px;
+      padding:0;
+    }
+    .func-math-field::part(content){
+      font-size:15px;
+      line-height:1.4;
+      padding:0;
     }
     .func-input .func-preview{
       display:none;
@@ -121,6 +154,7 @@
     #cfgFontSize{ width:48px; text-align:center; padding:6px 8px; }
   </style>
   <link rel="stylesheet" href="split.css" />
+  <script defer src="https://cdn.jsdelivr.net/npm/mathlive/dist/mathlive.min.js"></script>
 </head>
 <body>
   <div class="wrap">


### PR DESCRIPTION
## Summary
- embed MathLive assets and styling so graftegner uses a math-aware editor
- replace the old text inputs with MathLive fields and keep SIMPLE config in sync

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d25399f4c08324a8b26339ced1bb95