### PR TITLE
Fjern generer fasit knapp og skjul input når fasit vises

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -326,7 +326,6 @@
               <input id="exprInput" type="text" placeholder="Skriv funksjonsuttrykk, f.eks. (x+1)/((x-3)(x-2))" autocomplete="off">
             </label>
             <div class="toolbar-row">
-              <button class="btn" id="btnGenerate">Generer fasit</button>
               <label class="checkbox">
                 <input type="checkbox" id="autoSync"> Vis fasit
               </label>


### PR DESCRIPTION
## Summary
- remove the "Generer fasit" button so "Vis fasit" controls syncing on its own
- hide draggable input fields for nullpunkter when "Vis fasit" is active and show static values instead
- adjust messaging to guide users to enter a function when no fasit is available

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2556e3c7883249a63f22e40705f11