### PR TITLE
Adjust auto-sync critical point display

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -91,6 +91,16 @@
       font-weight: 600;
       color: #111827;
     }
+    .chart-overlay__value--locked {
+      padding: 0;
+      border: none;
+      border-radius: 0;
+      background: none;
+      box-shadow: none;
+      cursor: default;
+      gap: 0;
+      font-size: 16px;
+    }
     .chart-overlay__value input[type="number"] {
       width: 10ch;
       min-width: 8ch;

--- a/fortegnsskjema.js
+++ b/fortegnsskjema.js
@@ -1533,6 +1533,7 @@
         valueBadge.title = formatPointValue(point.value);
         valueBadge.dataset.pointId = point.id;
         if (chartLocked) {
+          valueBadge.classList.add('chart-overlay__value--locked');
           valueBadge.textContent = formatPointValue(point.value);
           valueBadge.style.pointerEvents = 'none';
         } else {


### PR DESCRIPTION
## Summary
- add a locked-state style for chart overlay values
- ensure auto-synced critical point values drop the badge formatting so they match factor labels

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d25a8ba2f8832484433a64e18deb55