### PR TITLE
Fix whitespace multiplication parsing in graftegner

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -317,7 +317,17 @@ function parseFunctionSpec(spec) {
   if (m) {
     rhs = m[2];
   }
-  rhs = rhs.replace(/(^|[=+\-*/])\s*([+-])\s*([a-zA-Z0-9._()]+)\s*\^/g, (m, p, s, b) => p + '0' + s + '(' + b + ')^').replace(/\^/g, '**').replace(/(\d)([a-zA-Z(])/g, '$1*$2').replace(/([x\)])\(/g, '$1*(').replace(/x(\d)/g, 'x*$1').replace(/\bln\(/gi, 'log(').replace(/\bpi\b/gi, 'PI').replace(/\be\b/gi, 'E').replace(/\btau\b/gi, '(2*PI)');
+  rhs = rhs
+    .replace(/(^|[=+\-*/])\s*([+-])\s*([a-zA-Z0-9._()]+)\s*\^/g, (m, p, s, b) => p + '0' + s + '(' + b + ')^')
+    .replace(/\^/g, '**')
+    .replace(/(\d)([a-zA-Z(])/g, '$1*$2')
+    .replace(/([x\)])\(/g, '$1*(')
+    .replace(/x(\d)/g, 'x*$1')
+    .replace(/\bln\(/gi, 'log(')
+    .replace(/\bpi\b/gi, 'PI')
+    .replace(/\be\b/gi, 'E')
+    .replace(/\btau\b/gi, '(2*PI)')
+    .replace(/(\bPI|\bE|[\d.)x])\s+(?=[a-zA-Z(0-9)])/g, '$1*');
   let fn;
   try {
     // eslint-disable-next-line no-new-func


### PR DESCRIPTION
## Summary
- ensure parseFunctionSpec inserts implicit multiplication when expressions contain whitespace between factors
- allow inputs like `f(x)=1/2 x^2` to render correctly by normalizing spacing to explicit multiplication

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d25bf52038832495fee454bc12ed58