### PR TITLE
Reset prikk-til-prikk view when board is cleared

### DIFF
--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -359,6 +359,11 @@
     hasUserAdjustedView = true;
   }
 
+  function resetViewToDefault() {
+    STATE.view = { zoom: DEFAULT_ZOOM, panX: 0, panY: 0 };
+    hasUserAdjustedView = false;
+  }
+
   function computePointBounds(points) {
     if (!Array.isArray(points) || !points.length) return null;
     let minX = Infinity;
@@ -1057,7 +1062,11 @@
     STATE.labelFontSize = normalizeLabelFontSize(STATE.labelFontSize);
     STATE.showGrid = !!STATE.showGrid;
     STATE.snapToGrid = !!STATE.snapToGrid;
-    ensureViewFitsPoints(sanitizedPoints);
+    if (sanitizedPoints.length === 0) {
+      resetViewToDefault();
+    } else {
+      ensureViewFitsPoints(sanitizedPoints);
+    }
     getViewSettings();
     if (predefAnchorPointId != null && !validPoints.has(predefAnchorPointId)) {
       predefAnchorPointId = null;


### PR DESCRIPTION
## Summary
- add a helper that clears the board view state and resets the user-adjusted flag
- invoke the helper when sanitizing state with no remaining points so the viewport snaps back to defaults

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d257c78a688324816882bfd4c0c04d