### PR TITLE
Flytt eksportfelt nederst i innstillinger

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -158,6 +158,7 @@
               <input id="color_6" type="color" value="#E31C3D" />
             </div>
           </fieldset>
+          <div id="figureSettings" class="figureSettings"></div>
           <fieldset>
             <legend>Eksport</legend>
             <div class="toolbar" id="exportToolbar">
@@ -165,7 +166,6 @@
               <button id="btnExportPng" class="btn" type="button">Last ned PNG</button>
             </div>
           </fieldset>
-          <div id="figureSettings" class="figureSettings"></div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- moved the export fieldset to appear below the dynamic figure settings so the export buttons stay at the bottom of the controls card

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2666686f88324bd85e3bf3fcf97f9