### PR TITLE
Embed font stack in fraction wall SVG

### DIFF
--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -150,6 +150,7 @@
       border: 1px solid #e5e7eb;
       box-shadow: inset 0 0 0 1px rgba(17, 24, 39, 0.04);
       overflow: visible;
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
     }
     .tile { cursor: pointer; outline: none; }
     .tile rect {
@@ -164,6 +165,7 @@
       stroke-width: 6;
     }
     .tile text {
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
       font-weight: 600;
       pointer-events: none;
       dominant-baseline: middle;
@@ -173,6 +175,7 @@
       transition: fill .2s ease;
     }
     .rowLabelText {
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
       font-size: 22px;
       font-weight: 600;
       fill: #334155;
@@ -180,6 +183,7 @@
       text-anchor: middle;
     }
     .rowLabelSub {
+      font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
       font-size: 12px;
       fill: #64748b;
       letter-spacing: .02em;


### PR DESCRIPTION
## Summary
- embed the page's system font stack in the fraction wall SVG and label text styles so exports retain typography

## Testing
- npm start -- --port 4173 (manual verification in browser)
- playwright export script to download SVG/PNG and inspect font-family

------
https://chatgpt.com/codex/tasks/task_e_68d27768689c83248cfe61e61ea4169b