### PR TITLE
Fix domain marker brackets to open toward the graph

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -1906,7 +1906,7 @@ function makeBracketAt(g, x0, side /* -1 = venstre (a), +1 = høyre (b) */, clos
     layer: ADV.domainMarkers.layer
   };
   const [ux, uy] = px2world(tx, ty, CAP);
-  const dir = -side;
+  const dir = side;
   const segments = [];
   if (closed) {
     const back = brd.create('segment', [A, B], style);


### PR DESCRIPTION
## Summary
- flip domain domain markers so their brackets open toward the graphed function

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d28aea8b9c8324a253ef4e9bb5cf39