### PR TITLE
Add KaTeX preview when editing point labels

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -263,6 +263,23 @@
       font-variant-numeric: tabular-nums;
     }
     .point-input--label { flex: 2 1 180px; }
+    .point-label-preview {
+      flex: 0 0 auto;
+      min-width: 48px;
+      min-height: 32px;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      padding: 4px 8px;
+      border-radius: 10px;
+      background: #f3f4f6;
+      color: #1f2937;
+      font-size: 14px;
+      font-weight: 600;
+      line-height: 1.2;
+      box-sizing: border-box;
+    }
+    .point-label-preview .katex { font-size: 1em; }
     .point-actions {
       margin-left: auto;
       display: flex;

--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -1155,6 +1155,7 @@
     if (!editor || !point) return;
     if (editor.labelInput) editor.labelInput.value = point.label;
     if (editor.coordInput) editor.coordInput.value = coordinateString(point);
+    if (editor.labelPreview) renderLatex(editor.labelPreview, getPointLabelText(point));
   }
 
   function updateLinesForPoint(pointId) {
@@ -2012,6 +2013,11 @@
       labelInput.placeholder = 'Tekst';
       labelInput.setAttribute('aria-label', 'Tekst');
       labelInput.value = point.label;
+      const labelPreview = document.createElement('span');
+      labelPreview.className = 'point-label-preview';
+      labelPreview.setAttribute('aria-hidden', 'true');
+      renderLatex(labelPreview, getPointLabelText(point));
+
       labelInput.addEventListener('input', () => {
         point.label = labelInput.value;
         const label = labelElements.get(point.id);
@@ -2019,8 +2025,10 @@
           label.setText(getPointLabelText(point));
           label.setVisibility(STATE.showLabels);
         }
+        renderLatex(labelPreview, getPointLabelText(point));
       });
       item.appendChild(labelInput);
+      item.appendChild(labelPreview);
 
       const actions = document.createElement('div');
       actions.className = 'point-actions';
@@ -2053,7 +2061,8 @@
       pointEditors.set(point.id, {
         itemEl: item,
         coordInput,
-        labelInput
+        labelInput,
+        labelPreview
       });
     });
 
@@ -2126,6 +2135,7 @@
       if (!editor) return;
       if (editor.labelInput) editor.labelInput.value = point.label;
       if (editor.coordInput) editor.coordInput.value = coordinateString(point);
+      if (editor.labelPreview) renderLatex(editor.labelPreview, getPointLabelText(point));
       if (editor.itemEl) editor.itemEl.dataset.pointId = point.id;
     });
   }


### PR DESCRIPTION
## Summary
- add styling for a point-label preview chip in the point list
- render KaTeX previews next to label inputs and keep them synced when editing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d28e8ab10c832485f6ef1ba9c03baf