### PR TITLE
Add beta badge to number line visualization

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,7 +229,7 @@
         </a>
       </li>
       <li>
-        <a href="tallinje.html" target="content" title="Tallinje" aria-label="Tallinje">
+        <a href="tallinje.html" target="content" title="Tallinje (beta)" aria-label="Tallinje (beta)">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <line x1="3" y1="16" x2="21" y2="16" stroke-linecap="round" />
             <line x1="6" y1="13" x2="6" y2="19" stroke-linecap="round" />
@@ -238,6 +238,7 @@
             <circle cx="14.5" cy="11" r="1.8" fill="currentColor" stroke="none" />
           </svg>
           <span class="sr-only">Tallinje</span>
+          <span class="nav-badge" aria-hidden="true">Beta</span>
         </a>
       </li>
       <li>

--- a/tallinje.html
+++ b/tallinje.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
-  <title>Tallinje</title>
+  <title>Tallinje (beta)</title>
   <link rel="stylesheet" href="base.css" />
   <style>
     :root { --gap: 18px; }


### PR DESCRIPTION
## Summary
- mark the number line navigation entry as a beta feature and add the badge to the icon
- update the number line page title to include the beta status

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d29d648ae0832480ec868219e92a11