### PR TITLE
Move Tallinje link to end of menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,18 +229,6 @@
         </a>
       </li>
       <li>
-        <a href="tallinje.html" target="content" title="Tallinje" aria-label="Tallinje">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <line x1="3" y1="16" x2="21" y2="16" stroke-linecap="round" />
-            <line x1="6" y1="13" x2="6" y2="19" stroke-linecap="round" />
-            <line x1="12" y1="13" x2="12" y2="19" stroke-linecap="round" />
-            <line x1="18" y1="13" x2="18" y2="19" stroke-linecap="round" />
-            <circle cx="14.5" cy="11" r="1.8" fill="currentColor" stroke="none" />
-          </svg>
-          <span class="sr-only">Tallinje</span>
-        </a>
-      </li>
-      <li>
         <a href="kuler.html" target="content" title="Kuler" aria-label="Kuler">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 11q9 9 18 0" />
@@ -309,6 +297,18 @@
           </svg>
           <span class="sr-only">Fortegnsskjema</span>
           <span class="nav-badge" aria-hidden="true">Beta</span>
+        </a>
+      </li>
+      <li>
+        <a href="tallinje.html" target="content" title="Tallinje" aria-label="Tallinje">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <line x1="3" y1="16" x2="21" y2="16" stroke-linecap="round" />
+            <line x1="6" y1="13" x2="6" y2="19" stroke-linecap="round" />
+            <line x1="12" y1="13" x2="12" y2="19" stroke-linecap="round" />
+            <line x1="18" y1="13" x2="18" y2="19" stroke-linecap="round" />
+            <circle cx="14.5" cy="11" r="1.8" fill="currentColor" stroke="none" />
+          </svg>
+          <span class="sr-only">Tallinje</span>
         </a>
       </li>
     </ul>


### PR DESCRIPTION
## Summary
- move the Tallinje menu item to the bottom of the main navigation list so it appears last in the menu

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d29ddc7ae08324bc40c7ba58bd638b