### PR TITLE
Move Tallinje menu link to end of navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -229,19 +229,6 @@
         </a>
       </li>
       <li>
-        <a href="tallinje.html" target="content" title="Tallinje (beta)" aria-label="Tallinje (beta)">
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
-            <line x1="3" y1="16" x2="21" y2="16" stroke-linecap="round" />
-            <line x1="6" y1="13" x2="6" y2="19" stroke-linecap="round" />
-            <line x1="12" y1="13" x2="12" y2="19" stroke-linecap="round" />
-            <line x1="18" y1="13" x2="18" y2="19" stroke-linecap="round" />
-            <circle cx="14.5" cy="11" r="1.8" fill="currentColor" stroke="none" />
-          </svg>
-          <span class="sr-only">Tallinje</span>
-          <span class="nav-badge" aria-hidden="true">Beta</span>
-        </a>
-      </li>
-      <li>
         <a href="kuler.html" target="content" title="Kuler" aria-label="Kuler">
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 11q9 9 18 0" />
@@ -309,6 +296,19 @@
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 18h16" />
           </svg>
           <span class="sr-only">Fortegnsskjema</span>
+          <span class="nav-badge" aria-hidden="true">Beta</span>
+        </a>
+      </li>
+      <li>
+        <a href="tallinje.html" target="content" title="Tallinje (beta)" aria-label="Tallinje (beta)">
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
+            <line x1="3" y1="16" x2="21" y2="16" stroke-linecap="round" />
+            <line x1="6" y1="13" x2="6" y2="19" stroke-linecap="round" />
+            <line x1="12" y1="13" x2="12" y2="19" stroke-linecap="round" />
+            <line x1="18" y1="13" x2="18" y2="19" stroke-linecap="round" />
+            <circle cx="14.5" cy="11" r="1.8" fill="currentColor" stroke="none" />
+          </svg>
+          <span class="sr-only">Tallinje</span>
           <span class="nav-badge" aria-hidden="true">Beta</span>
         </a>
       </li>


### PR DESCRIPTION
## Summary
- reorder the Tallinje navigation entry so it appears last in the main menu

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d29f37305c832498eee9c208b1c7be