### PR TITLE
Prevent dragging points in play mode

### DIFF
--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -1197,6 +1197,10 @@
     event.preventDefault();
     const point = STATE.points.find(p => p && p.id === pointId);
     if (!point) return false;
+    if (!isEditMode) {
+      handlePointSelection(pointId);
+      return true;
+    }
     const pointerId = event.pointerId;
     const dragThreshold = getPointDragThreshold(event);
     const startClientX = event.clientX;


### PR DESCRIPTION
## Summary
- stop attaching drag handlers to board points while in play mode
- invoke point selection immediately so clicks no longer nudge point positions during gameplay

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68d2a46553a88324aded41e6edaa77ab