### PR TITLE
Fix prikk til prikk point scaling origin

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -311,6 +311,8 @@
       stroke: none;
       pointer-events: none;
       transition: transform .2s ease, filter .2s ease, fill .2s ease;
+      -webkit-transform-box: fill-box;
+      transform-box: fill-box;
       transform-origin: center;
     }
     .point.is-selected .point-dot {


### PR DESCRIPTION
## Summary
- ensure prikk til prikk point scaling uses its own bounding box so dots stay put when selected

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2af2fe4908324ab98fdd0a1c16e18