### PR TITLE
Fix missing length label for horizontal split area model

### DIFF
--- a/arealmodellen1.js
+++ b/arealmodellen1.js
@@ -644,7 +644,7 @@ function draw() {
   const showGrid = ADV.grid !== false;
   const clickToMove = ADV.clickToMove !== false;
   const showHeightAxis = layoutMode !== "horizontal" && rows > 1 && ((_SV$height2 = SV.height) === null || _SV$height2 === void 0 ? void 0 : _SV$height2.show) !== false;
-  const showLengthAxis = layoutMode !== "vertical" && cols > 1 && ((_SV$length2 = SV.length) === null || _SV$length2 === void 0 ? void 0 : _SV$length2.show) !== false;
+  const showLengthAxis = cols > 1 && ((_SV$length2 = SV.length) === null || _SV$length2 === void 0 ? void 0 : _SV$length2.show) !== false;
   const dragVertical = layoutMode !== "single" && showHeightAxis && ((_ADV$drag = ADV.drag) === null || _ADV$drag === void 0 ? void 0 : _ADV$drag.vertical) !== false;
   const dragHorizontal = layoutMode !== "single" && showLengthAxis && ((_ADV$drag2 = ADV.drag) === null || _ADV$drag2 === void 0 ? void 0 : _ADV$drag2.horizontal) !== false;
   const splitLinesOn = ADV.splitLines !== false;


### PR DESCRIPTION
## Summary
- allow the length axis to render when the layout is horizontally split so the width is displayed

## Testing
- no automated tests available

------
https://chatgpt.com/codex/tasks/task_e_68d2ddcc632c832485101054205ed16e