### PR TITLE
Improve point selection feedback in prikk til prikk oppgavemodus

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -305,6 +305,10 @@
       fill: transparent;
       stroke: none;
       pointer-events: all;
+      transition: transform .2s ease, fill .2s ease, stroke .2s ease, stroke-width .2s ease;
+      -webkit-transform-box: fill-box;
+      transform-box: fill-box;
+      transform-origin: center;
     }
     .point-dot {
       fill: #111827;
@@ -315,15 +319,27 @@
       transform-box: fill-box;
       transform-origin: center;
     }
+    .point.is-selected .point-decoration {
+      fill: rgba(37, 99, 235, 0.18);
+      stroke: #2563eb;
+      stroke-width: 3;
+      transform: scale(1.18);
+    }
     .point.is-selected .point-dot {
-      transform: scale(1.3);
-      filter: drop-shadow(0 0 4px rgba(37, 99, 235, 0.45));
+      fill: #2563eb;
+      transform: scale(1.35);
+      filter: drop-shadow(0 0 6px rgba(37, 99, 235, 0.55));
     }
     .point--false .point-dot {
       fill: #b91c1c;
     }
+    .point--false.point.is-selected .point-decoration {
+      fill: rgba(185, 28, 28, 0.18);
+      stroke: #b91c1c;
+    }
     .point--false.point.is-selected .point-dot {
-      filter: drop-shadow(0 0 4px rgba(185, 28, 28, 0.45));
+      fill: #b91c1c;
+      filter: drop-shadow(0 0 6px rgba(185, 28, 28, 0.55));
     }
     .point-label {
       font-size: 14px;

--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -2375,6 +2375,7 @@
     }
     selectedPointId = pointId;
     renderBoard();
+    applySelectionHighlight();
   }
 
   function showStatus(type, heading, detailLines) {


### PR DESCRIPTION
## Summary
- strengthen the visual feedback when a dot is selected with a colored halo and brighter fill
- ensure false points receive matching selection styling so the active dot stays obvious
- reapply the selection highlight after redrawing user lines so the last clicked dot remains marked

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d2df77c5988324b90cba5b111147b2