### PR TITLE
Show glider controls for placeholder linear functions

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -2843,7 +2843,9 @@ function setupSettingsForm() {
     const value = getFirstFunctionValue();
     if (!value) return false;
     if (isCoords(value)) return false;
-    return isExplicitFun(value);
+    if (isExplicitFun(value)) return true;
+    const forced = determineForcedGliderCount(value);
+    return forced != null && forced > 0;
   };
   const hasConfiguredPoints = () => {
     const parsedMode = SIMPLE_PARSED ? decideMode(SIMPLE_PARSED) : 'functions';


### PR DESCRIPTION
## Summary
- ensure glider controls appear when placeholder linear functions (e.g. f(x)=ax+b) trigger forced points
- allow authors to configure the start position for the auto-added points

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d2e09bb1a883248b1f8392899a4082