### PR TITLE
Improve factoring and expression display for fortegnsskjema

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -67,6 +67,24 @@
       overflow: hidden;
       position: relative;
     }
+    .chart-expression {
+      position: absolute;
+      top: 14px;
+      left: 18px;
+      pointer-events: none;
+      font-size: 22px;
+      font-weight: 600;
+      color: #111827;
+      min-height: 28px;
+      display: flex;
+      align-items: center;
+    }
+    .chart-expression--empty {
+      display: none;
+    }
+    .chart-expression .katex {
+      font-size: 1.05em;
+    }
     .chart-overlay {
       position: absolute;
       inset: 0;
@@ -333,6 +351,7 @@
     <div class="grid">
       <div class="card">
         <div class="figure">
+          <div id="chartExpression" class="chart-expression chart-expression--empty" aria-hidden="true"></div>
           <svg id="chart" role="img" aria-label="Fortegnsskjema"></svg>
           <div id="chartOverlay" class="chart-overlay"></div>
         </div>
@@ -423,7 +442,7 @@
       </div>
     </div>
   </div>
-
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/mathlive/dist/mathlive.min.js"></script>
   <script src="fortegnsskjema.js"></script>
   <script src="split.js"></script>


### PR DESCRIPTION
## Summary
- show the current expression on the fortegnsskjema figure using KaTeX and respect optional f(x)= prefixes
- capture raw expression input details so we can remember whether the user included a function prefix
- infer missing linear factors from detected zeros so expressions like x^2-1 still yield full factor rows, while skipping the helper row when only one factor exists

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2dd1b337883248f49218695e00735