### PR TITLE
Oppdater prikk-til-prikk etiketter

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -263,23 +263,6 @@
       font-variant-numeric: tabular-nums;
     }
     .point-input--label { flex: 2 1 180px; }
-    .point-label-preview {
-      flex: 0 0 auto;
-      min-width: 48px;
-      min-height: 32px;
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 4px 8px;
-      border-radius: 10px;
-      background: #f3f4f6;
-      color: #1f2937;
-      font-size: 14px;
-      font-weight: 600;
-      line-height: 1.2;
-      box-sizing: border-box;
-    }
-    .point-label-preview .katex { font-size: 1em; }
     .point-actions {
       margin-left: auto;
       display: flex;
@@ -342,7 +325,7 @@
       filter: drop-shadow(0 0 6px rgba(185, 28, 28, 0.55));
     }
     .point-label {
-      font-size: 14px;
+      font-size: 16px;
       font-weight: 600;
       fill: #111827;
       paint-order: stroke;
@@ -357,7 +340,7 @@
       position: absolute;
       inset: 0;
       pointer-events: none;
-      font-size: 14px;
+      font-size: 16px;
       line-height: 1.4;
       z-index: 0;
     }
@@ -478,7 +461,7 @@
             <span class="settings-range__label">Skriftstørrelse</span>
             <select id="cfg-labelFontSize">
               <option value="12">Liten</option>
-              <option value="14" selected>Standard</option>
+              <option value="16" selected>Standard</option>
               <option value="18">Stor</option>
               <option value="24">Ekstra stor</option>
             </select>

--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -9,7 +9,7 @@
   const LABEL_EDGE_MARGIN = 16;
   const LABEL_LINE_AVOIDANCE_THRESHOLD = Math.PI / 8;
   const LABEL_LINE_PENALTY = 100;
-  const DEFAULT_LABEL_FONT_SIZE = 14;
+  const DEFAULT_LABEL_FONT_SIZE = 16;
   const POINT_DRAG_START_DISTANCE_PX = 4;
   const POINT_DRAG_START_DISTANCE_COARSE_PX = 12;
   const MIN_LABEL_FONT_SIZE = 10;
@@ -1173,7 +1173,6 @@
     if (!editor || !point) return;
     if (editor.labelInput) editor.labelInput.value = point.label;
     if (editor.coordInput) editor.coordInput.value = coordinateString(point);
-    if (editor.labelPreview) renderLatex(editor.labelPreview, getPointLabelText(point));
   }
 
   function updateLinesForPoint(pointId) {
@@ -2035,11 +2034,6 @@
       labelInput.placeholder = 'Tekst';
       labelInput.setAttribute('aria-label', 'Tekst');
       labelInput.value = point.label;
-      const labelPreview = document.createElement('span');
-      labelPreview.className = 'point-label-preview';
-      labelPreview.setAttribute('aria-hidden', 'true');
-      renderLatex(labelPreview, getPointLabelText(point));
-
       labelInput.addEventListener('input', () => {
         point.label = labelInput.value;
         const label = labelElements.get(point.id);
@@ -2047,10 +2041,8 @@
           label.setText(getPointLabelText(point));
           label.setVisibility(STATE.showLabels);
         }
-        renderLatex(labelPreview, getPointLabelText(point));
       });
       item.appendChild(labelInput);
-      item.appendChild(labelPreview);
 
       const actions = document.createElement('div');
       actions.className = 'point-actions';
@@ -2083,8 +2075,7 @@
       pointEditors.set(point.id, {
         itemEl: item,
         coordInput,
-        labelInput,
-        labelPreview
+        labelInput
       });
     });
 
@@ -2157,7 +2148,6 @@
       if (!editor) return;
       if (editor.labelInput) editor.labelInput.value = point.label;
       if (editor.coordInput) editor.coordInput.value = coordinateString(point);
-      if (editor.labelPreview) renderLatex(editor.labelPreview, getPointLabelText(point));
       if (editor.itemEl) editor.itemEl.dataset.pointId = point.id;
     });
   }


### PR DESCRIPTION
## Summary
- fjernet forhåndsvisningen av punktetiketten bak tekstfeltet i redigeringspanelet
- økte standardskriftstørrelsen for etiketter til 16 px og oppdaterte kontrollvalget

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d2e53d987c8324800497bd93b6b093