### PR TITLE
Set default expression text in fortegnsskjema

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -389,9 +389,9 @@
                 id="exprInput"
                 virtual-keyboard-mode="off"
                 smart-mode="false"
-                placeholder="Skriv funksjonsuttrykk, f.eks. (x+1)/((x-3)(x-2))"
+                value="x-1"
                 aria-label="Funksjonsuttrykk"
-              ></math-field>
+              >x-1</math-field>
             </label>
             <div class="toolbar-row">
               <label class="checkbox">


### PR DESCRIPTION
## Summary
- remove the placeholder text from the fortegnsskjema expression input
- provide x-1 as the initial value so the field is prefilled instead of empty

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d2ea1dd41483248bbd94d951d20912