### PR TITLE
Remove label editor from prikktilprikk points list and bump default font size

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -461,8 +461,8 @@
             <span class="settings-range__label">Skriftstørrelse</span>
             <select id="cfg-labelFontSize">
               <option value="12">Liten</option>
-              <option value="16" selected>Standard</option>
-              <option value="18">Stor</option>
+              <option value="16">Standard</option>
+              <option value="18" selected>Stor</option>
               <option value="24">Ekstra stor</option>
             </select>
           </label>

--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -9,7 +9,7 @@
   const LABEL_EDGE_MARGIN = 16;
   const LABEL_LINE_AVOIDANCE_THRESHOLD = Math.PI / 8;
   const LABEL_LINE_PENALTY = 100;
-  const DEFAULT_LABEL_FONT_SIZE = 16;
+  const DEFAULT_LABEL_FONT_SIZE = 18;
   const POINT_DRAG_START_DISTANCE_PX = 4;
   const POINT_DRAG_START_DISTANCE_COARSE_PX = 12;
   const MIN_LABEL_FONT_SIZE = 10;
@@ -2028,22 +2028,6 @@
       });
       item.appendChild(coordInput);
 
-      const labelInput = document.createElement('input');
-      labelInput.type = 'text';
-      labelInput.className = 'point-input point-input--label';
-      labelInput.placeholder = 'Tekst';
-      labelInput.setAttribute('aria-label', 'Tekst');
-      labelInput.value = point.label;
-      labelInput.addEventListener('input', () => {
-        point.label = labelInput.value;
-        const label = labelElements.get(point.id);
-        if (label) {
-          label.setText(getPointLabelText(point));
-          label.setVisibility(STATE.showLabels);
-        }
-      });
-      item.appendChild(labelInput);
-
       const actions = document.createElement('div');
       actions.className = 'point-actions';
 
@@ -2074,8 +2058,7 @@
       targetList.appendChild(item);
       pointEditors.set(point.id, {
         itemEl: item,
-        coordInput,
-        labelInput
+        coordInput
       });
     });
 


### PR DESCRIPTION
## Summary
- remove the manual label text input from the dot-to-dot point editor so each row only shows coordinates and actions
- increase the default point label font size to 18 and update the UI dropdown to match

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d2e9e3a1908324ac58c0722f0e6a90