### PR TITLE
Remove automatic example download on save

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -915,40 +915,6 @@
     } else {
       alert('Eksempel lagret. Klarte ikke å kopiere JSON til utklipp automatisk.');
     }
-
-    // Also offer download of the example as a JS file
-    try {
-      const lines = [];
-      const cfg = ex.config || {};
-      if (cfg.STATE) lines.push(`window.STATE=${JSON.stringify(cfg.STATE)};`);
-      if (cfg.CFG) lines.push(`window.CFG=${JSON.stringify(cfg.CFG)};`);
-      if (cfg.CONFIG) lines.push(`window.CONFIG=${JSON.stringify(cfg.CONFIG)};`);
-      if (cfg.SIMPLE) lines.push(`window.SIMPLE=${JSON.stringify(cfg.SIMPLE)};`);
-
-      // Include all external scripts in the downloaded file
-      const scripts = Array.from(document.querySelectorAll('script[src]')).filter(s => !s.src.endsWith('examples.js'));
-      for (const s of scripts) {
-        try {
-          const res = await fetch(s.src);
-          const txt = await res.text();
-          lines.push(`// Source: ${s.src}`);
-          lines.push(txt);
-        } catch (error) {}
-      }
-      const blob = new Blob([lines.join('\n')], {
-        type: 'application/javascript'
-      });
-      const a = document.createElement('a');
-      a.href = URL.createObjectURL(blob);
-      const base = location.pathname.split('/').pop().replace(/\.html$/, '');
-      a.download = `${base}-example-${examples.length}.js`;
-      document.body.appendChild(a);
-      a.click();
-      setTimeout(() => {
-        URL.revokeObjectURL(a.href);
-        document.body.removeChild(a);
-      }, 1000);
-    } catch (error) {}
   });
   deleteBtn === null || deleteBtn === void 0 || deleteBtn.addEventListener('click', () => {
     const examples = getExamples();


### PR DESCRIPTION
## Summary
- stop triggering the automatic JS download when saving an example so that only the clipboard copy remains

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d3055505808324831ee9c82064aa62