### PR TITLE
Adjust glider controls layout and visibility

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -103,6 +103,28 @@
     .func-row--main label,
     .func-row--gliders label{ width:100%; }
     .func-fields--first .func-row label{ width:100%; }
+    .func-row--gliders label{ justify-self:start; }
+    .func-row--gliders{
+      display:grid;
+      gap:12px;
+      grid-template-columns:repeat(auto-fit,minmax(160px,1fr));
+      align-items:end;
+    }
+    .func-row--gliders .linepoints-row{
+      display:contents;
+    }
+    .func-row--gliders label.points,
+    .func-row--gliders label.linepoint{
+      max-width:180px;
+    }
+    .func-row--gliders label.linepoint input,
+    .func-row--gliders label.points select{
+      max-width:100%;
+    }
+    .func-row--gliders .startx-label{
+      grid-column:1 / -1;
+      max-width:180px;
+    }
     @media (max-width:680px){
       .function-controls{ align-items:stretch; }
       .func-group .func-fields{ grid-template-columns:1fr; }

--- a/graftegner.js
+++ b/graftegner.js
@@ -3067,7 +3067,7 @@ function setupSettingsForm() {
     const count = getGliderCount();
     gliderStartInput.disabled = !active || count <= 0;
     if (gliderStartLabel) {
-      gliderStartLabel.style.display = active && count > 0 ? '' : 'none';
+      gliderStartLabel.style.display = active ? '' : 'none';
     }
     updateSnapAvailability();
   };
@@ -3230,19 +3230,19 @@ function setupSettingsForm() {
                 <option value="2">2</option>
               </select>
             </label>
+            <div class="linepoints-row">
+              <label class="linepoint" data-linepoint-label="0">
+                <span>Punkt 1 (x, y)</span>
+                <input type="text" data-linepoint="0" placeholder="0, 0">
+              </label>
+              <label class="linepoint" data-linepoint-label="1">
+                <span>Punkt 2 (x, y)</span>
+                <input type="text" data-linepoint="1" placeholder="1, 1">
+              </label>
+            </div>
             <label class="startx-label">
               <span>Startposisjon, x</span>
               <input type="text" data-startx value="1" placeholder="1">
-            </label>
-          </div>
-          <div class="func-row func-row--linepoints linepoints-row">
-            <label class="linepoint" data-linepoint-label="0">
-              <span>Punkt 1 (x, y)</span>
-              <input type="text" data-linepoint="0" placeholder="0, 0">
-            </label>
-            <label class="linepoint" data-linepoint-label="1">
-              <span>Punkt 2 (x, y)</span>
-              <input type="text" data-linepoint="1" placeholder="1, 1">
             </label>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- keep the start position field visible whenever glider points are enabled
- arrange the glider point controls on a single row and shorten their inputs for a tighter layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d30adcad9883249e151347576eeee7