### PR TITLE
Hide duplicate expression label in fortegnsskjema chart

### DIFF
--- a/fortegnsskjema.js
+++ b/fortegnsskjema.js
@@ -1949,6 +1949,11 @@
     if (!expressionDisplay) {
       return;
     }
+    if (Array.isArray(state.signRows) && state.signRows.length > 0) {
+      expressionDisplay.textContent = '';
+      expressionDisplay.classList.add('chart-expression--empty');
+      return;
+    }
     const expr = typeof state.expression === 'string' ? state.expression.trim() : '';
     if (!expr) {
       expressionDisplay.textContent = '';


### PR DESCRIPTION
## Summary
- hide the standalone chart expression overlay when sign rows are present so the label only appears next to its sign line

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d30f67c9d88324b86830632d6687bc