### PR TITLE
Add Playwright test for Kuler export downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules/
+playwright-report/
+test-results/

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,9 @@
         "@babel/core": "^7.28.4",
         "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
         "@babel/plugin-transform-optional-chaining": "^7.27.1",
-        "http-server": "^14.1.1"
+        "@playwright/test": "^1.42.0",
+        "http-server": "^14.1.1",
+        "pngjs": "^7.0.0"
       }
     },
     "node_modules/@babel/cli": {
@@ -403,6 +405,22 @@
       "dev": true,
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.55.1.tgz",
+      "integrity": "sha512-IVAh/nOJaw6W9g+RJVlIQJ6gSiER+ae6mKQ5CX1bERzQgbC1VSeBlwdvczT7pxb0GWiyrxH4TGKbMfDb4Sq/ig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/@upstash/redis": {
       "version": "1.35.4",
@@ -1371,6 +1389,63 @@
       "license": "MIT",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.55.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.55.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/portfinder": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "arealmodell0.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "playwright test",
     "start": "npx http-server -c-1"
   },
   "keywords": [],
@@ -17,7 +17,9 @@
     "@babel/core": "^7.28.4",
     "@babel/plugin-transform-nullish-coalescing-operator": "^7.27.1",
     "@babel/plugin-transform-optional-chaining": "^7.27.1",
-    "http-server": "^14.1.1"
+    "@playwright/test": "^1.42.0",
+    "http-server": "^14.1.1",
+    "pngjs": "^7.0.0"
   },
   "dependencies": {
     "@vercel/kv": "^3.0.0"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,17 @@
+const { defineConfig } = require('@playwright/test');
+
+module.exports = defineConfig({
+  testDir: 'tests',
+  timeout: 60000,
+  retries: process.env.CI ? 2 : 0,
+  use: {
+    baseURL: 'http://127.0.0.1:4173',
+    acceptDownloads: true
+  },
+  webServer: {
+    command: 'npx http-server -c-1 -p 4173',
+    url: 'http://127.0.0.1:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120000
+  }
+});

--- a/tests/export-buttons.spec.js
+++ b/tests/export-buttons.spec.js
@@ -1,0 +1,49 @@
+const { test, expect } = require('@playwright/test');
+const fs = require('fs');
+const { PNG } = require('pngjs');
+
+async function collectUniqueColors(png) {
+  const unique = new Set();
+  const data = png.data;
+  for (let i = 0; i < data.length; i += 4) {
+    const alpha = data[i + 3];
+    if (!alpha) continue;
+    const key = `${data[i]},${data[i + 1]},${data[i + 2]},${alpha}`;
+    unique.add(key);
+    if (unique.size > 32) break;
+  }
+  return unique;
+}
+
+test.describe('Kuler export buttons', () => {
+  test('exported SVG and PNG have expected content', async ({ page }, testInfo) => {
+    await page.goto('/kuler.html', { waitUntil: 'load' });
+
+    const svgDownloadPromise = page.waitForEvent('download');
+    await page.click('#downloadSVG1');
+    const svgDownload = await svgDownloadPromise;
+    expect(svgDownload.suggestedFilename()).toBe('kuler1.svg');
+    const svgPath = testInfo.outputPath('kuler-export.svg');
+    await svgDownload.saveAs(svgPath);
+
+    const svgContent = await fs.promises.readFile(svgPath, 'utf-8');
+    expect(svgContent).toContain('<svg');
+    expect(svgContent).toContain('viewBox="0 0 500 300"');
+    expect(svgContent).not.toContain('href="images/');
+    expect(svgContent).toMatch(/<image[^>]+href="data:image\/svg\+xml;base64/);
+
+    const pngDownloadPromise = page.waitForEvent('download');
+    await page.click('#downloadPNG1');
+    const pngDownload = await pngDownloadPromise;
+    expect(pngDownload.suggestedFilename()).toBe('kuler1.png');
+    const pngPath = testInfo.outputPath('kuler-export.png');
+    await pngDownload.saveAs(pngPath);
+
+    const pngBuffer = await fs.promises.readFile(pngPath);
+    const png = PNG.sync.read(pngBuffer);
+    expect(png.width).toBe(500);
+    expect(png.height).toBe(300);
+    const colors = await collectUniqueColors(png);
+    expect(colors.size).toBeGreaterThan(10);
+  });
+});


### PR DESCRIPTION
## Summary
- add an automated Playwright test that opens kuler.html and verifies the SVG/PNG export buttons
- configure Playwright to run against a local http-server and accept downloads, and add png parsing helper
- update npm test script and ignore Playwright output directories

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc47820a8832491cd1f9aee2f21c8