### PR TITLE
Use sessionStorage fallback when localStorage fails

### DIFF
--- a/examples-viewer.js
+++ b/examples-viewer.js
@@ -1,6 +1,6 @@
 // Viewer for stored examples
 const globalScope = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
-function createFallbackStorage() {
+function createMemoryStorage() {
   const data = new Map();
   return {
     get length() {
@@ -33,6 +33,58 @@ function createFallbackStorage() {
       data.clear();
     }
   };
+}
+function createSessionFallbackStorage() {
+  if (typeof sessionStorage === 'undefined') return null;
+  try {
+    const testKey = '__examples_session_test__';
+    sessionStorage.setItem(testKey, '1');
+    sessionStorage.removeItem(testKey);
+  } catch (_) {
+    return null;
+  }
+  return {
+    get length() {
+      try {
+        const value = sessionStorage.length;
+        return typeof value === 'number' ? value : 0;
+      } catch (_) {
+        return 0;
+      }
+    },
+    key(index) {
+      try {
+        return sessionStorage.key(index);
+      } catch (_) {
+        return null;
+      }
+    },
+    getItem(key) {
+      try {
+        return sessionStorage.getItem(key);
+      } catch (_) {
+        return null;
+      }
+    },
+    setItem(key, value) {
+      try {
+        sessionStorage.setItem(key, value);
+      } catch (_) {}
+    },
+    removeItem(key) {
+      try {
+        sessionStorage.removeItem(key);
+      } catch (_) {}
+    },
+    clear() {
+      try {
+        sessionStorage.clear();
+      } catch (_) {}
+    }
+  };
+}
+function createFallbackStorage() {
+  return createSessionFallbackStorage() || createMemoryStorage();
 }
 const sharedFallback = (() => {
   if (globalScope && globalScope.__EXAMPLES_FALLBACK_STORAGE__ && typeof globalScope.__EXAMPLES_FALLBACK_STORAGE__.getItem === 'function') {

--- a/examples.js
+++ b/examples.js
@@ -28,7 +28,7 @@
 
 (function () {
   const globalScope = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
-  function createFallbackStorage() {
+  function createMemoryStorage() {
     const data = new Map();
     return {
       get length() {
@@ -62,6 +62,58 @@
         data.clear();
       }
     };
+  }
+  function createSessionFallbackStorage() {
+    if (typeof sessionStorage === 'undefined') return null;
+    try {
+      const testKey = '__examples_session_test__';
+      sessionStorage.setItem(testKey, '1');
+      sessionStorage.removeItem(testKey);
+    } catch (_) {
+      return null;
+    }
+    return {
+      get length() {
+        try {
+          const value = sessionStorage.length;
+          return typeof value === 'number' ? value : 0;
+        } catch (_) {
+          return 0;
+        }
+      },
+      key(index) {
+        try {
+          return sessionStorage.key(index);
+        } catch (_) {
+          return null;
+        }
+      },
+      getItem(key) {
+        try {
+          return sessionStorage.getItem(key);
+        } catch (_) {
+          return null;
+        }
+      },
+      setItem(key, value) {
+        try {
+          sessionStorage.setItem(key, value);
+        } catch (_) {}
+      },
+      removeItem(key) {
+        try {
+          sessionStorage.removeItem(key);
+        } catch (_) {}
+      },
+      clear() {
+        try {
+          sessionStorage.clear();
+        } catch (_) {}
+      }
+    };
+  }
+  function createFallbackStorage() {
+    return createSessionFallbackStorage() || createMemoryStorage();
   }
   const fallbackStorage = (() => {
     if (globalScope && globalScope.__EXAMPLES_FALLBACK_STORAGE__ && typeof globalScope.__EXAMPLES_FALLBACK_STORAGE__.getItem === 'function') {

--- a/router.js
+++ b/router.js
@@ -27,7 +27,7 @@
 })();
 
 const globalScope = typeof window !== 'undefined' ? window : typeof globalThis !== 'undefined' ? globalThis : null;
-function createFallbackStorage() {
+function createMemoryStorage() {
   const data = new Map();
   return {
     get length() {
@@ -60,6 +60,58 @@ function createFallbackStorage() {
       data.clear();
     }
   };
+}
+function createSessionFallbackStorage() {
+  if (typeof sessionStorage === 'undefined') return null;
+  try {
+    const testKey = '__examples_session_test__';
+    sessionStorage.setItem(testKey, '1');
+    sessionStorage.removeItem(testKey);
+  } catch (_) {
+    return null;
+  }
+  return {
+    get length() {
+      try {
+        const value = sessionStorage.length;
+        return typeof value === 'number' ? value : 0;
+      } catch (_) {
+        return 0;
+      }
+    },
+    key(index) {
+      try {
+        return sessionStorage.key(index);
+      } catch (_) {
+        return null;
+      }
+    },
+    getItem(key) {
+      try {
+        return sessionStorage.getItem(key);
+      } catch (_) {
+        return null;
+      }
+    },
+    setItem(key, value) {
+      try {
+        sessionStorage.setItem(key, value);
+      } catch (_) {}
+    },
+    removeItem(key) {
+      try {
+        sessionStorage.removeItem(key);
+      } catch (_) {}
+    },
+    clear() {
+      try {
+        sessionStorage.clear();
+      } catch (_) {}
+    }
+  };
+}
+function createFallbackStorage() {
+  return createSessionFallbackStorage() || createMemoryStorage();
 }
 const sharedFallback = (() => {
   if (globalScope && globalScope.__EXAMPLES_FALLBACK_STORAGE__ && typeof globalScope.__EXAMPLES_FALLBACK_STORAGE__.getItem === 'function') {


### PR DESCRIPTION
## Summary
- add a sessionStorage-backed fallback storage for saved examples when localStorage throws
- update the shared example viewer and router to reuse the persistent fallback

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd4337c3cc83248a74cbc1496ce134