### PR TITLE
Fix mobile layout for Brøkfigurer controls

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -135,6 +135,7 @@
     .input--digit{width:60px;padding:8px 10px;border:1px solid #d1d5db;border-radius:10px;font-size:14px;background:#fff;box-sizing:border-box;text-align:center;}
     .box svg *:focus{outline:none;}
     @media(max-width:720px){
+      .grid{grid-template-columns:1fr;grid-template-rows:auto auto;}
       .figure-board{grid-template-columns:1fr;grid-template-rows:auto auto auto;}
       .figure-controls--cols{grid-column:1;grid-row:2;flex-direction:row;}
       .figure-controls--rows{grid-column:1;grid-row:3;justify-self:center;}


### PR DESCRIPTION
## Summary
- adjust the single-column grid layout on narrow screens so the figure board card expands to its content
- keep the figure controls stacked without colliding with the settings panels on mobile

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dda51ddf0c8324afa4dd48babb7305