### PR TITLE
Add automatic alt text for Arealmodell and Nkant

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -136,7 +136,7 @@
             </div>
           </div>
         </div>
-        <div class="card">
+        <div class="card" id="exportCard">
           <h2>Eksporter</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
@@ -148,6 +148,7 @@
       </div>
     </div>
   </div>
+  <script src="alt-text-ui.js"></script>
   <script src="arealmodellen1.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>

--- a/nkant.html
+++ b/nkant.html
@@ -289,7 +289,7 @@ Rettvinklet trekant</textarea>
           <label><input type="radio" name="layout" value="col"> Under hverandre</label>
         </div>
       </div>
-        <div class="card">
+        <div class="card" id="exportCard">
           <h2>Eksporter</h2>
           <div class="toolbar">
             <button id="btnSvg" class="btn" type="button">Last ned SVG</button>
@@ -299,6 +299,7 @@ Rettvinklet trekant</textarea>
     </div>
   </div>
 
+  <script src="alt-text-ui.js"></script>
   <script src="nkant.js"></script>
   <script src="examples.js"></script>
   <script src="split.js"></script>


### PR DESCRIPTION
## Summary
- integrate the shared alt-text UI in Arealmodell and generate descriptions based on layout, grid, labels, and challenge state while adding the text to exports
- wire the alt-text UI into Nkant and auto-generate summaries for the rendered polygons, including layout and side/angle data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68ddad1c14e48324941107d99b870aff