### PR TITLE
Improve fortegnsskjema mobile interactions

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -110,6 +110,7 @@
       font-size: 15px;
       font-weight: 600;
       color: #111827;
+      touch-action: none;
     }
     .chart-overlay__value--locked {
       padding: 0;
@@ -151,6 +152,20 @@
       -moz-appearance: textfield;
       appearance: textfield;
       cursor: text;
+    }
+    @media (max-width: 520px) {
+      .chart-overlay__value {
+        transform: translate(-50%, -110%);
+        padding: 4px 6px;
+        gap: 4px;
+        font-size: 14px;
+      }
+      .chart-overlay__value-input {
+        padding: 2px 4px;
+        font-size: 14px;
+        width: 7ch;
+        min-width: 0;
+      }
     }
     .domain-controls {
       display: flex;
@@ -201,6 +216,7 @@
       width: 100%;
       height: 560px;
       display: block;
+      touch-action: none;
     }
     .toolbar,
     .controls,

--- a/fortegnsskjema.js
+++ b/fortegnsskjema.js
@@ -2084,6 +2084,7 @@
         'pointer-events': chartLocked ? 'none' : 'all',
         cursor: chartLocked ? 'default' : 'ew-resize'
       });
+      dragHandle.style.touchAction = 'none';
       svg.append(dragHandle);
       if (overlay) {
         const valueBadge = document.createElement('div');
@@ -2092,6 +2093,7 @@
         valueBadge.style.top = `${arrowY}px`;
         valueBadge.title = formatPointValue(point.value);
         valueBadge.dataset.pointId = point.id;
+        valueBadge.style.touchAction = 'none';
         if (chartLocked) {
           valueBadge.classList.add('chart-overlay__value--locked');
           valueBadge.textContent = formatPointValue(point.value);
@@ -2253,7 +2255,7 @@
           'alignment-baseline': 'middle',
           'font-size': isPole ? 22 : 20,
           'font-weight': 700,
-          fill: isPole ? '#b91c1c' : '#111827',
+          fill: '#111827',
           cursor: chartLocked ? 'default' : 'pointer'
         });
         marker.textContent = isPole ? '><' : '0';


### PR DESCRIPTION
## Summary
- make the breakpoint markers display in black for consistency with other chart elements
- add touch-action adjustments to SVG handles and overlays to improve drag responsiveness on touch devices
- tighten overlay badge sizing on small screens so number inputs fit better on iPhone

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68de59c13e348324a50271ddaea447f0