### PR TITLE
Fix alt text sync when switching examples

### DIFF
--- a/alt-text-ui.js
+++ b/alt-text-ui.js
@@ -192,8 +192,12 @@
     return {
       refresh(reason) {
         const current = normalizeState(getState());
+        if (textarea && textarea.value !== current.text) {
+          textarea.value = current.text;
+        }
+        applyToSvg(current.text);
         if (current.source === 'manual' && current.text.trim()) {
-          applyToSvg(current.text);
+          setStatus('', false);
           return;
         }
         setStatus('Oppdaterer alternativ tekst …', false);


### PR DESCRIPTION
## Summary
- ensure the shared alt-text manager updates the textarea when state changes
- avoid stale alternative text lingering after switching between examples

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dea78d60c0832484fc76474dc2f10a