### PR TITLE
Improve CI test job labeling

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    name: Shared styling & Playwright tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers (Chromium, Firefox, WebKit)
+        run: npx playwright install --with-deps
+
+      - name: Check shared CSS variables and base styles
+        run: node tests/check-shared-styles.js
+
+      - name: Run Playwright end-to-end suite
+        run: npx playwright test


### PR DESCRIPTION
## Summary
- rename the CI test job to "Shared styling & Playwright tests" for clearer status reporting
- split the previous `npm test` step into separate named steps for the shared-style check and the Playwright suite so GitHub shows descriptive step titles

## Testing
- node tests/check-shared-styles.js
- npx playwright test tests/styling-consistency.spec.js --project=chromium --grep "arealmodell.html" --reporter=line *(fails: CSS expectations return empty strings)*

------
https://chatgpt.com/codex/tasks/task_e_68deafdda2ec83249779072419f6a6b2