### PR TITLE
Add testing instructions for Codex environment

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,30 @@
+# Kjøre tester i Codex-miljøet
+
+Dette prosjektet har allerede en testpakke konfigurert gjennom npm-skriptet `npm test`. Skriptet kjører først et tilpasset stil-sjekkverktøy og deretter Playwright sine ende-til-ende-tester.
+
+## Forberedelser
+1. Installer avhengigheter:
+   ```bash
+   npm install
+   ```
+
+2. (Valgfritt) Sørg for at du har bygget eventuelle statiske ressurser som testene forventer. De fleste testene i dette repoet bruker de rå HTML/JS-filene og trenger ikke en eksplisitt build.
+
+## Kjøre testene
+Kjør følgende kommando fra rotmappen til prosjektet:
+
+```bash
+npm test
+```
+
+Dette vil:
+1. Kjør `node tests/check-shared-styles.js` for å kontrollere at delte stiler er konsistente.
+2. Kjør `playwright test` for å starte Playwright-testene definert i `tests/`-mappen.
+
+> **Tips:** Dersom Playwright ikke er installert i miljøet ennå, vil `npm install`-steget ovenfor ta seg av det.
+
+## Feilsøking
+- **Manglende nettleserbinærer:** Playwright kan be deg kjøre `npx playwright install` første gang. Det kan du trygt gjøre i Codex før du lager PR.
+- **Treg testoppstart:** Playwright starter en lokal HTTP-server under `npm test`. I Codex skjer dette automatisk via testene.
+
+Med dette oppsettet kan du trygt kjøre hele testpakken i Codex før du lager en PR til GitHub.


### PR DESCRIPTION
## Summary
- add documentation describing how to run the existing npm test suite inside Codex
- include troubleshooting tips for Playwright browser installation before creating a PR

## Testing
- npm test *(fails: Playwright browsers need to be installed with `npx playwright install`)*

------
https://chatgpt.com/codex/tasks/task_e_68debb38d1a08324b2d0eb6e6bc0f9ef