### PR TITLE
Ensure Playwright browsers are available before tests run

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,6 +4,7 @@ module.exports = defineConfig({
   testDir: 'tests',
   timeout: 60000,
   retries: process.env.CI ? 2 : 0,
+  globalSetup: require.resolve('./tests/global-setup.js'),
   use: {
     baseURL: 'http://127.0.0.1:4173',
     acceptDownloads: true

--- a/tests/global-setup.js
+++ b/tests/global-setup.js
@@ -1,0 +1,14 @@
+const { execSync } = require('child_process');
+
+module.exports = async () => {
+  if (process.env.PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD === '1') {
+    return;
+  }
+
+  try {
+    execSync('npx playwright install', { stdio: 'inherit' });
+  } catch (error) {
+    console.error('Failed to ensure Playwright browsers are installed.');
+    throw error;
+  }
+};


### PR DESCRIPTION
## Summary
- add a Playwright global setup script that installs browsers on demand
- wire the new setup into the Playwright configuration so CI no longer misses browser binaries
- allow opting out via `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD`

## Testing
- npm test *(fails: styling-consistency assertions are currently red, but browsers now install so the suite runs)*

------
https://chatgpt.com/codex/tasks/task_e_68debf2ff6508324b4ccda35571e1537