### PR TITLE
Fix fallback storage detection when localStorage access fails

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -126,13 +126,19 @@
     return store;
   })();
   let usingFallbackStorage = false;
-  function ensureFallbackStorage() {
-    if (!usingFallbackStorage) {
-      usingFallbackStorage = true;
-      if (typeof localStorage !== 'undefined') {
+    function ensureFallbackStorage() {
+      if (!usingFallbackStorage) {
+        usingFallbackStorage = true;
+        let localStorageAvailable = false;
         try {
-          const total = Number(localStorage.length) || 0;
-          for (let i = 0; i < total; i++) {
+          localStorageAvailable = typeof localStorage !== 'undefined';
+        } catch (_) {
+          localStorageAvailable = false;
+        }
+        if (localStorageAvailable) {
+          try {
+            const total = Number(localStorage.length) || 0;
+            for (let i = 0; i < total; i++) {
             let key = null;
             try {
               key = localStorage.key(i);


### PR DESCRIPTION
## Summary
- guard the fallback storage initialization against localStorage access errors
- ensure we still switch to the shared fallback storage when localStorage is unavailable

## Testing
- npx playwright test tests/examples-cross-browser.spec.js --project=chromium --grep "fallback storage" --reporter=line
- npx playwright test tests/examples-cross-browser.spec.js --grep "fallback storage" --reporter=line

------
https://chatgpt.com/codex/tasks/task_e_68defaba593c8324a0202da5ac18b1ed