### PR TITLE
Limit Firefox and WebKit runs to cross-browser tests

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,5 +1,7 @@
 const { defineConfig, devices } = require('@playwright/test');
 
+const CROSS_BROWSER_TESTS = 'tests/examples-cross-browser.spec.js';
+
 module.exports = defineConfig({
   testDir: 'tests',
   timeout: 60000,
@@ -16,10 +18,12 @@ module.exports = defineConfig({
     },
     {
       name: 'firefox',
+      testMatch: CROSS_BROWSER_TESTS,
       use: { ...devices['Desktop Firefox'] }
     },
     {
       name: 'webkit',
+      testMatch: CROSS_BROWSER_TESTS,
       use: { ...devices['Desktop Safari'] }
     }
   ],


### PR DESCRIPTION
## Summary
- restrict the Firefox and WebKit Playwright projects to only run the dedicated cross-browser suite so the majority of tests execute once in Chromium

## Testing
- npm test *(fails locally: Playwright browser dependencies are missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68df79a09e508324a566d96c947a92ad