### PR TITLE
Ensure shared base theme is applied synchronously across visualizations

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -6,7 +6,40 @@
   <title>Arealmodell</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; }
     html,body { height: 100%; }
     body {

--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -7,7 +7,40 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; }
     html,body{height:100%;}
     body{

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -6,7 +6,40 @@
   <title>Arealmodell B</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; }
     html,body { height: 100%; }
     body {

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -9,7 +9,40 @@
   <!-- JSXGraph -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css">
   <script src="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraphcore.js"></script>
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap:18px; --purple:#5B2AA5; --rim:#333; --dash:#000; }
     html,body{height:100%;}
     body{

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -7,7 +7,40 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
 
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --purple:#5B2AA5; --rim:#333; --dash:#000; --gap:18px; }
     html,body { height:100%; }
     body {

--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -6,7 +6,40 @@
   <title>Brøkvegg</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; --purple:#5B2AA5; }
     html, body { height: 100%; }
     body {

--- a/figurtall.html
+++ b/figurtall.html
@@ -6,7 +6,40 @@
   <title>Figurtall</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap:18px; --card-min:240px; }
     html,body{height:100%;}
     body{

--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -7,7 +7,40 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mathlive/dist/mathlive-static.css" />
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; }
     html, body { height: 100%; }
     body {

--- a/graftegner.html
+++ b/graftegner.html
@@ -10,7 +10,40 @@
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/mathlive/dist/mathlive-static.css" />
 
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; }
     html,body { height: 100%; }
     body{

--- a/index.html
+++ b/index.html
@@ -3,8 +3,42 @@
 <head>
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <link rel="stylesheet" href="base.css" />
   <title>Math Visuals</title>
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     *, *::before, *::after {
       box-sizing: border-box;
     }

--- a/kuler.html
+++ b/kuler.html
@@ -6,7 +6,40 @@
   <title>Kuler</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap:18px; }
     html,body{height:100%;}
     body{

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -5,7 +5,40 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Numbervisuals</title>
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; }
     html,body{height:100%;}
     body{

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -5,7 +5,40 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Kvikkbilder</title>
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; }
     html,body{height:100%;}
     body{

--- a/nkant.html
+++ b/nkant.html
@@ -5,7 +5,40 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Nkant – én SVG med flere figurer</title>
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; }
     html,body { height: 100%; }
     body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -5,7 +5,40 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Perlesnor</title>
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; }
     html, body { height: 100%; }
     body {

--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -6,7 +6,40 @@
   <title>Prikk til prikk (beta)</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" />
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; }
     html, body { height: 100%; }
     body {

--- a/tallinje.html
+++ b/tallinje.html
@@ -5,7 +5,40 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Tallinje</title>
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; }
     html, body { height: 100%; }
     body {

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -6,7 +6,40 @@
   <title>Tenkeblokker</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap:18px; }
     html,body{height:100%;}
     body{

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -6,7 +6,40 @@
   <title>Tenkeblokker</title>
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root {
       --gap: 18px;
       --tb-stepper-gap: 0px;

--- a/trefigurer.html
+++ b/trefigurer.html
@@ -5,7 +5,40 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Trefigurer</title>
   <link rel="stylesheet" href="base.css" />
-  <style>
+  <style data-base-theme>
+    :root {
+      --surface-bg: #f7f8fb;
+      --text-color: #111827;
+      --control-radius: 10px;
+    }
+    body {
+      margin: 0;
+      background: var(--surface-bg);
+      color: var(--text-color);
+      font-family: system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+      padding: 20px;
+    }
+    .btn {
+      appearance: none;
+      border: 1px solid #d1d5db;
+      background: #fff;
+      border-radius: var(--control-radius);
+      padding: 8px 12px;
+      font-size: 14px;
+      cursor: pointer;
+      transition: box-shadow 0.2s, transform 0.02s;
+      font-family: inherit;
+      color: inherit;
+    }
+    .btn:hover {
+      box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
+    }
+    .btn:active {
+      transform: translateY(1px);
+    }
+  </style>
+
+<style>
     :root { --gap: 18px; }
     html, body { height: 100%; }
     body {


### PR DESCRIPTION
## Summary
- add an inline base theme block to every standalone visualization so the shared CSS variables, body styling, and button appearance are available immediately on load
- link the shared base.css stylesheet from index.html to keep the landing page aligned with the rest of the visualizations

## Testing
- not run (Playwright browsers require additional system dependencies in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68df7d7dc5c08324a2b41095a2b099b5