### PR TITLE
Align fraction figure settings with layout

### DIFF
--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -161,11 +161,21 @@
     .btn{appearance:none;border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 12px;font-size:14px;cursor:pointer;transition:box-shadow .2s,transform .02s}
     .btn:hover{box-shadow:0 2px 8px rgba(0,0,0,.06)}
     .btn:active{transform:translateY(1px)}
-    .figureSettings{display:grid;gap:var(--gap);grid-template-columns:repeat(auto-fit,minmax(220px,1fr));align-items:stretch;}
-    .figureSettings fieldset{min-width:0;}
+    .figureSettings{
+      --figure-settings-cols:1;
+      --figure-settings-rows:1;
+      display:grid;
+      gap:var(--gap);
+      align-items:stretch;
+      grid-template-columns:repeat(var(--figure-settings-cols),minmax(0,1fr));
+      grid-template-rows:repeat(var(--figure-settings-rows),minmax(0,1fr));
+      grid-auto-flow:row;
+    }
+    .figureSettings fieldset{min-width:0;width:100%;}
     .colors{display:flex;flex-wrap:wrap;gap:6px;}
     .colors input{flex:0 0 40px;width:40px;height:40px;}
     .input--digit{width:60px;padding:8px 10px;border:1px solid #d1d5db;border-radius:10px;font-size:14px;background:#fff;box-sizing:border-box;text-align:center;}
+    .input--digit.input--small{width:52px;}
     .box svg *:focus{outline:none;}
     @media(max-width:720px){
       .grid{grid-template-columns:1fr;grid-template-rows:auto auto;}

--- a/brøkfigurer.js
+++ b/brøkfigurer.js
@@ -387,7 +387,7 @@
         </select>
       </label>
       <label>Antall deler
-        <input id="parts${id}" type="number" min="1" value="4" />
+        <input id="parts${id}" class="input--digit input--small" type="number" min="1" value="4" />
       </label>
       <label>Delt
         <select id="division${id}">
@@ -447,6 +447,10 @@
         if (legend) legend.textContent = `Figur ${id}`;
         settingsContainer.appendChild(fieldset);
       }
+      settingsContainer.style.setProperty('--figure-settings-cols', String(cols));
+      settingsContainer.style.setProperty('--figure-settings-rows', String(rows));
+      settingsContainer.dataset.cols = String(cols);
+      settingsContainer.dataset.rows = String(rows);
     }
     activeFigureIds = ids;
     updateLayoutControls();


### PR DESCRIPTION
## Summary
- align the figure-specific settings grid with the figure board layout
- shorten the "antall deler" number field for each figure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68df94a858c48324b75a343757628a71