### PR TITLE
Allow selecting points by clicking labels

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -390,6 +390,7 @@
       display: inline-flex;
       align-items: center;
       gap: 4px;
+      pointer-events: auto;
     }
     .board-label--false {
       color: #b91c1c;

--- a/prikktilprikk.js
+++ b/prikktilprikk.js
@@ -783,6 +783,12 @@
     const wrapper = document.createElement('div');
     wrapper.className = 'board-label';
     if (point && point.isFalse) wrapper.classList.add('board-label--false');
+    const pointId = point && point.id ? point.id : null;
+    if (pointId) wrapper.dataset.pointId = pointId;
+    wrapper.addEventListener('pointerdown', event => {
+      if (!pointId) return;
+      handlePointPointerDown(wrapper, pointId, event);
+    });
     if (!STATE.showLabels) wrapper.style.display = 'none';
     const content = document.createElement('span');
     content.className = 'board-label-content';


### PR DESCRIPTION
## Summary
- allow board labels to pass pointer events to the same handlers as their underlying points
- enable pointer events on labels so clicking a label selects the associated point

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df9bad87808324be4320cb4d5274e9