### PR TITLE
Update optional label text for max y on diagram page

### DIFF
--- a/diagram/index.html
+++ b/diagram/index.html
@@ -70,7 +70,7 @@
               <label>Min y (valgfritt)
                 <input id="cfgYMin" type="text" value="0">
               </label>
-              <label>Maks y (valgfritt)
+              <label>Maks y
                 <input id="cfgYMax" type="text" value="8">
               </label>
               <label>Navn på x-akse


### PR DESCRIPTION
## Summary
- remove the "(valgfritt)" suffix from the Max y label in the diagram tool so it simply reads "Maks y"

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfaa9013cc832480545a85a4bdaf45