### PR TITLE
Remove clipboard copying when saving examples

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -226,33 +226,6 @@
       return `${base}${sep}path=${encodeURIComponent(path)}`;
     }
   }
-  async function copyTextToClipboard(text) {
-    if (typeof text !== 'string') return false;
-    try {
-      if (typeof navigator !== 'undefined' && navigator.clipboard && typeof navigator.clipboard.writeText === 'function') {
-        await navigator.clipboard.writeText(text);
-        return true;
-      }
-    } catch (error) {}
-    try {
-      const textarea = document.createElement('textarea');
-      textarea.value = text;
-      textarea.setAttribute('readonly', '');
-      textarea.style.position = 'fixed';
-      textarea.style.top = '-1000px';
-      textarea.style.opacity = '0';
-      document.body.appendChild(textarea);
-      textarea.select();
-      textarea.setSelectionRange(0, textarea.value.length);
-      let copied = false;
-      if (typeof document.execCommand === 'function') {
-        copied = document.execCommand('copy');
-      }
-      document.body.removeChild(textarea);
-      return !!copied;
-    } catch (error) {}
-    return false;
-  }
   if (globalScope && !globalScope.__EXAMPLES_STORAGE__) {
     try {
       if (typeof localStorage !== 'undefined') {
@@ -1554,27 +1527,16 @@
       if (loadExample(idx)) initialLoadPerformed = true;
     }
   }
-  saveBtn === null || saveBtn === void 0 || saveBtn.addEventListener('click', async () => {
+  saveBtn === null || saveBtn === void 0 || saveBtn.addEventListener('click', () => {
     const examples = getExamples();
     const ex = collectConfig();
     examples.push(ex);
     store(examples, {
       reason: 'manual-save'
     });
-    let clipboardCopied = false;
-    try {
-      const serialized = JSON.stringify(examples);
-      if (serialized) {
-        clipboardCopied = await copyTextToClipboard(serialized);
-      }
-    } catch (error) {}
     currentExampleIndex = examples.length - 1;
     renderOptions();
-    if (clipboardCopied) {
-      alert('Eksempel lagret. JSON-strengen ble kopiert til utklipp.');
-    } else {
-      alert('Eksempel lagret. Klarte ikke å kopiere JSON til utklipp automatisk.');
-    }
+    alert('Eksempel lagret.');
   });
   deleteBtn === null || deleteBtn === void 0 || deleteBtn.addEventListener('click', () => {
     const examples = getExamples();


### PR DESCRIPTION
## Summary
- remove clipboard copying logic when saving an example
- simplify save confirmation alert copy

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dfaed9cfc88324ba04928b8dc37ccc