### PR TITLE
Add inside label placement option for pie charts

### DIFF
--- a/diagram.css
+++ b/diagram.css
@@ -80,6 +80,7 @@ body {
 .pie-slice{stroke:#fff;stroke-width:2;cursor:pointer}
 .pie-divider{stroke:#fff;stroke-width:2;stroke-dasharray:6 6;opacity:.6}
 .pie-label{fill:#333;font-size:16px;font-weight:600;pointer-events:none}
+.pie-label--inside{fill:#fff;text-shadow:0 1px 2px rgba(0,0,0,.4)}
 .pie-label__value{font-size:14px;font-weight:400;pointer-events:none}
 .pie-slice-0{fill:#4f2c8c}
 .pie-slice-1{fill:#6c3db5}

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -64,6 +64,12 @@
                 <option value="percent">Prosent</option>
               </select>
             </label>
+            <label id="cfgPieLabelPositionWrapper" style="display:none">Plassering sektoretiketter
+              <select id="cfgPieLabelPosition">
+                <option value="outside" selected>Utside</option>
+                <option value="inside">Innside</option>
+              </select>
+            </label>
             <label>Overskrift
               <input id="cfgTitle" type="text" value="Favorittidretter i 5B">
             </label>


### PR DESCRIPTION
## Summary
- add a configurable setting to place pie labels inside their sectors
- update pie rendering logic to honor the new placement and style inside labels
- expose the placement control in the settings UI with supporting styles

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfd255ff388324b619e2b1c466c280