### PR TITLE
Fix example 2 display for fortegnsskjema

### DIFF
--- a/fortegnsskjema.js
+++ b/fortegnsskjema.js
@@ -731,12 +731,6 @@
           segments: [-1, 1, -1, 1],
           role: 'result',
           locked: false
-        }, {
-          id: 'row-2',
-          label: 'Observasjon',
-          segments: [-1, -1, 1, 1],
-          role: 'custom',
-          locked: false
         }],
         solution: null
       }
@@ -1963,11 +1957,6 @@
   }
   function renderExpressionDisplay() {
     if (!expressionDisplay) {
-      return;
-    }
-    if (Array.isArray(state.signRows) && state.signRows.length > 0) {
-      expressionDisplay.textContent = '';
-      expressionDisplay.classList.add('chart-expression--empty');
       return;
     }
     const expr = typeof state.expression === 'string' ? state.expression.trim() : '';


### PR DESCRIPTION
## Summary
- show the configured expression in the chart even when sign rows are present
- remove the extra "Observasjon" helper row from the rational function example so only the result line remains

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfd3ed17088324bc4975a70cf9cc37