### PR TITLE
Bundle modern-normalize in shared base styles

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Arealmodell</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
   <style data-base-theme>
     :root {

--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Arealmodell A</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css" />
   <style data-base-theme>

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Arealmodell B</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
   <style data-base-theme>
     :root {

--- a/base.css
+++ b/base.css
@@ -1,3 +1,108 @@
+/*! modern-normalize v3.0.1 | MIT License | https://github.com/sindresorhus/modern-normalize */
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html {
+  font-family: system-ui, "Segoe UI", Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji";
+  line-height: 1.15;
+  -webkit-text-size-adjust: 100%;
+  tab-size: 4;
+}
+
+body {
+  margin: 0;
+}
+
+b,
+strong {
+  font-weight: bolder;
+}
+
+code,
+kbd,
+samp,
+pre {
+  font-family: ui-monospace, SFMono-Regular, Consolas, "Liberation Mono", Menlo, monospace;
+  font-size: 1em;
+}
+
+small {
+  font-size: 80%;
+}
+
+sub,
+sup {
+  font-size: 75%;
+  line-height: 0;
+  position: relative;
+  vertical-align: baseline;
+}
+
+sub {
+  bottom: -0.25em;
+}
+
+sup {
+  top: -0.5em;
+}
+
+table {
+  border-color: currentColor;
+}
+
+button,
+input,
+optgroup,
+select,
+textarea {
+  font-family: inherit;
+  font-size: 100%;
+  line-height: 1.15;
+  margin: 0;
+}
+
+button,
+input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+  -webkit-appearance: button;
+}
+
+legend {
+  padding: 0;
+}
+
+progress {
+  vertical-align: baseline;
+}
+
+::-webkit-inner-spin-button,
+::-webkit-outer-spin-button {
+  height: auto;
+}
+
+input[type="search"] {
+  -webkit-appearance: textfield;
+  outline-offset: -2px;
+}
+
+::-webkit-search-decoration {
+  -webkit-appearance: none;
+}
+
+::-webkit-file-upload-button {
+  -webkit-appearance: button;
+  font: inherit;
+}
+
+summary {
+  display: list-item;
+}
+
 :root {
   --gap: 18px;
   --surface-bg: #f7f8fb;
@@ -81,6 +186,7 @@ body {
 
 .btn {
   appearance: none;
+  -webkit-appearance: none;
   border: 1px solid #d1d5db;
   background: #fff;
   border-radius: var(--control-radius);

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Brøkfigurer</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
   <!-- JSXGraph -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/jsxgraph/distrib/jsxgraph.css">

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Brøksirkler</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
 
   <style data-base-theme>

--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Brøkvegg</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
   <style data-base-theme>
     :root {

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -4,8 +4,7 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Interaktivt stolpediagram (UU)</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
-  <link rel="stylesheet" href="../base.css" />
+    <link rel="stylesheet" href="../base.css" />
   <link rel="stylesheet" href="../diagram.css" />
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.9/dist/katex.min.css" integrity="sha384-ywTprUI1Q+mEFz1Ok5AR52lCstOEPCTpQJZMa2+pzSQPwXTwns32xERiqnnn6T5+" crossorigin="anonymous" />
 

--- a/figurtall.html
+++ b/figurtall.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Figurtall</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
   <style data-base-theme>
     :root {

--- a/kuler.html
+++ b/kuler.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Kuler</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
   <style data-base-theme>
     :root {

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Tenkeblokker</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
   <style data-base-theme>
     :root {

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -4,7 +4,6 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Tenkeblokker</title>
-  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/modern-normalize/modern-normalize.css" />
   <link rel="stylesheet" href="base.css" />
   <style data-base-theme>
     :root {


### PR DESCRIPTION
## Summary
- embed the modern-normalize reset into `base.css` so shared styling inherits consistent defaults
- drop the per-app CDN reset includes since the baseline now ships with the bundle

## Testing
- npm test *(fails: Playwright requires additional system dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e23af4ac448324a2d5b5db433a29a8