### PR TITLE
Refactor sidebar layouts to shared class

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -50,9 +50,8 @@
       padding: 20px;
     }
     .wrap { max-width: 1200px; margin: 0 auto; display: flex; flex-direction: column; gap: var(--gap); }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 360px; align-items: start; }
+    .grid { --sidebar-width: 360px; }
     .side { display:flex; flex-direction:column; gap:var(--gap); }
-    @media (max-width:980px){ .grid { grid-template-columns: 1fr; } }
     .card {
       background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
       box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 14px;
@@ -95,7 +94,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card card--canvas">
         <div class="area-container">
           <svg id="area" preserveAspectRatio="xMidYMid meet" aria-label="Arealmodell"></svg>

--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -51,9 +51,8 @@
       padding:20px;
     }
     .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    .grid{--sidebar-width:360px;}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;
       box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
@@ -85,7 +84,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="box" class="jxgbox" aria-label="Arealmodell rektangel"></div>
         <div class="toolbar">

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -50,9 +50,8 @@
       padding: 20px;
     }
     .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 360px; align-items: start; }
+    .grid { --sidebar-width: 360px; }
     .side { display:flex; flex-direction:column; gap:var(--gap); }
-    @media (max-width:980px){ .grid { grid-template-columns: 1fr; } }
     .card {
       background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
       box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 14px;
@@ -107,7 +106,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <svg id="area" preserveAspectRatio="xMidYMid meet" aria-label="Arealmodell"></svg>
       </div>

--- a/base.css
+++ b/base.css
@@ -8,6 +8,7 @@
   --card-border: #e5e7eb;
   --card-radius: 14px;
   --control-radius: 10px;
+  --sidebar-width: 420px;
 }
 
 html,
@@ -32,6 +33,16 @@ body {
   display: grid;
   gap: var(--gap);
   align-items: start;
+}
+
+.layout--sidebar {
+  grid-template-columns: minmax(0, 1fr) minmax(0, var(--sidebar-width));
+}
+
+@media (max-width: 980px) {
+  .layout--sidebar {
+    grid-template-columns: minmax(0, 1fr);
+  }
 }
 
 .side {

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -48,9 +48,8 @@
       color:#111827; background:#f7f8fb; padding:20px;
     }
     .wrap { max-width:1200px; margin:0 auto; }
-    .grid { display:grid; gap:var(--gap); grid-template-columns:1fr 360px; align-items:start; }
+    .grid { --sidebar-width:360px; }
     .side { display:flex; flex-direction:column; gap:var(--gap); }
-    @media (max-width:980px){ .grid { grid-template-columns:1fr; } }
     .card {
       background:#fff; border:1px solid #e5e7eb; border-radius:14px;
       box-shadow:0 1px 2px rgba(0,0,0,.04); padding:14px;
@@ -171,7 +170,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
 
       <div class="card">
         <div class="grid2">

--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -50,8 +50,7 @@
       padding: 20px;
     }
     .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 360px; align-items: start; }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
+    .grid { --sidebar-width: 360px; }
     .side { display: flex; flex-direction: column; gap: var(--gap); }
     .card {
       background: #fff;
@@ -238,7 +237,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card wallCard">
         <div class="wallToolbar" aria-label="Bytt visning for alle biter">
           <span class="wallToolbar__label">Standardvisning:</span>

--- a/diagram.css
+++ b/diagram.css
@@ -5,9 +5,8 @@ body {
   color: #111827; background: #f7f8fb; padding: 20px;
 }
 .wrap { max-width: 1200px; margin: 0 auto; }
-.grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
+.grid { --sidebar-width: 480px; }
 .side { display:flex; flex-direction:column; gap:var(--gap); }
-@media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
 .card {
   background: #fff; border: 1px solid #e5e7eb; border-radius: 14px;
   box-shadow: 0 1px 2px rgba(0,0,0,.04); padding: 14px; display: flex;

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -17,7 +17,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <h2 id="chartTitle">Favorittidretter i 5B</h2>
         <div class="figure">

--- a/figurtall.html
+++ b/figurtall.html
@@ -47,8 +47,7 @@
       color:#111827; background:#f7f8fb; padding:20px;
     }
     .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:minmax(0,1fr) clamp(260px,32vw,360px);align-items:start;}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
+    .grid{--sidebar-width:clamp(260px,32vw,360px);}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
     .grid2{
       --panel-min:clamp(200px,22vw,260px);
@@ -177,7 +176,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="figureContainer" class="grid2">
           <button id="addFigure" class="addFigureBtn" type="button" aria-label="Legg til figur">+</button>

--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -58,18 +58,12 @@
       gap: var(--gap);
     }
     .grid {
-      display: grid;
-      gap: var(--gap);
-      grid-template-columns: 1fr 380px;
-      align-items: start;
+      --sidebar-width: 380px;
     }
     .side {
       display: flex;
       flex-direction: column;
       gap: var(--gap);
-    }
-    @media (max-width: 1000px) {
-      .grid { grid-template-columns: 1fr; }
     }
     .card {
       background: #fff;
@@ -425,7 +419,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div class="figure">
           <div id="chartExpression" class="chart-expression chart-expression--empty" aria-hidden="true"></div>

--- a/graftegner.html
+++ b/graftegner.html
@@ -55,9 +55,7 @@
       font-family:system-ui,-apple-system,"Segoe UI",Roboto,Inter,Arial,sans-serif; color:#111827;
     }
     .wrap{ max-width:1200px; margin:0 auto; }
-    .grid{ display:grid; gap:var(--gap); grid-template-columns:1fr 420px; align-items:start; }
     .side{ display:flex; flex-direction:column; gap:var(--gap); }
-    @media (max-width:980px){ .grid{ grid-template-columns:1fr; } }
     .card{ background:#fff; border:1px solid #e5e7eb; border-radius:14px; box-shadow:0 1px 2px rgba(0,0,0,.04); padding:14px; display:flex; flex-direction:column; gap:10px; }
     .card h2{ margin:0 0 6px 2px; font-size:16px; font-weight:600; color:#374151; }
     .figure{ border-radius:10px; background:#fafbfc; overflow:hidden; border:1px solid #eef0f3; }
@@ -250,7 +248,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div class="figure">
           <div id="board" aria-label="JSXGraph-tavle"></div>

--- a/kuler.html
+++ b/kuler.html
@@ -47,7 +47,7 @@
       color:#111827; background:#f7f8fb; padding:20px;
     }
     .wrap{max-width:1400px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    .grid{--sidebar-width:360px;}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
     .figureGrid{
       --figure-columns:1;
@@ -67,7 +67,6 @@
     .figurePanel .btn{align-self:center;}
     .removeFigureBtn[disabled]{opacity:0.5;cursor:not-allowed;}
     .addFigureBtn{width:clamp(36px,8vw,56px);aspect-ratio:1;border:2px dashed #cfcfcf;border-radius:10px;background:#fff;display:flex;align-items:center;justify-content:center;font-size:18px;color:#6b7280;cursor:pointer;justify-self:center;align-self:center;}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     @media(max-width:720px){.figureGrid{--figure-columns:1;justify-items:center;}.figurePanel{max-width:100%;}.figure{max-width:100%;}.addFigureBtn{width:clamp(36px,14vw,60px);}}
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;
@@ -102,7 +101,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div class="figureGrid">
           <div id="panel1" class="figurePanel">

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -49,9 +49,8 @@
       padding:20px;
     }
     .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    .grid{--sidebar-width:360px;}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;
       box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
@@ -121,7 +120,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="figureArea" class="figure-area">
           <button id="playBtn" aria-label="Vis numbervisual">▶</button>

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -49,9 +49,8 @@
       padding:20px;
     }
     .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    .grid{--sidebar-width:360px;}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;
       box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
@@ -151,7 +150,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="figureArea" class="figure-area">
           <button id="playBtn" aria-label="Vis kvikkbilde">▶</button>

--- a/nkant.html
+++ b/nkant.html
@@ -44,9 +44,8 @@
     body { margin: 0; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, "Helvetica Neue", Arial, "Noto Sans";
            color: #111827; background: #f7f8fb; padding: 20px; }
     .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
+    .grid { --sidebar-width: 480px; }
     .side { display:flex; flex-direction:column; gap:var(--gap); }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
     .card { background: #fff; border: 1px solid #e5e7eb; border-radius: 14px; box-shadow: 0 1px 2px rgba(0,0,0,.04);
             padding: 14px; display: flex; flex-direction: column; gap: 10px; }
     .card h2 { margin: 0 0 6px 2px; font-size: 16px; font-weight: 600; color: #374151; }
@@ -74,7 +73,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div class="figure">
           <svg id="paper" viewBox="0 0 600 420" preserveAspectRatio="xMidYMid meet" aria-label=""></svg>

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -49,9 +49,8 @@
       padding: 20px;
     }
     .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 480px; align-items: start; }
+    .grid { --sidebar-width: 480px; }
     .side { display:flex; flex-direction:column; gap:var(--gap); }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
     .card {
       background: #fff;
       border: 1px solid #e5e7eb;
@@ -91,7 +90,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div class="figure">
           <svg id="beadSVG" viewBox="0 0 1400 460" role="img" aria-label="Perlesnor med klype"></svg>

--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -50,9 +50,7 @@
       padding: 20px;
     }
     .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 420px; align-items: start; }
     .side { display: flex; flex-direction: column; gap: var(--gap); }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
     .card {
       background: #fff;
       border: 1px solid #e5e7eb;
@@ -430,7 +428,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card card--board">
         <div class="toolbar toolbar--mode">
           <button id="btnToggleMode" class="btn btn--primary" type="button">Gå til oppgavemodus</button>

--- a/tallinje.html
+++ b/tallinje.html
@@ -49,9 +49,7 @@
       padding: 20px;
     }
     .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 420px; align-items: start; }
     .side { display: flex; flex-direction: column; gap: var(--gap); }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
     .card {
       background: #fff;
       border: 1px solid #e5e7eb;
@@ -100,7 +98,7 @@
     }
     input[type="number"]:disabled { background: #f3f4f6; color: #9ca3af; }
     .field-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
-    @media (max-width: 600px) { .grid { grid-template-columns: 1fr; } .field-grid { grid-template-columns: 1fr; } }
+    @media (max-width: 600px) { .field-grid { grid-template-columns: 1fr; } }
     .hint {
       margin: 4px 2px 0;
       font-size: 12px;
@@ -153,7 +151,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div class="figure">
           <svg id="numberLineSvg" viewBox="0 0 1000 260" preserveAspectRatio="xMidYMid meet" aria-label=""></svg>

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -50,9 +50,8 @@
       padding:20px;
     }
     .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:1fr 360px;align-items:start;}
+    .grid{--sidebar-width:360px;}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;
       box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
@@ -78,7 +77,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="blocks" aria-label="Tenkeblokker"></div>
         <div class="toolbar">

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -51,9 +51,8 @@
       color:#111827; background:#f7f8fb; padding:20px;
     }
     .wrap{max-width:1200px;margin:0 auto;}
-    .grid{display:grid;gap:var(--gap);grid-template-columns:minmax(0,1fr) minmax(320px,420px);align-items:start;}
+    .grid{--sidebar-width:clamp(320px,32vw,420px);}
     .side{display:flex;flex-direction:column;gap:var(--gap);}
-    @media(max-width:980px){.grid{grid-template-columns:1fr;}}
     .card{
       background:#fff;border:1px solid #e5e7eb;border-radius:14px;
       box-shadow:0 1px 2px rgba(0,0,0,.04);padding:14px;
@@ -202,7 +201,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="tbBoard" class="tb-board">
           <div id="tbGrid" class="tb-grid" data-cols="1"></div>

--- a/trefigurer.html
+++ b/trefigurer.html
@@ -49,8 +49,6 @@
       padding: 20px;
     }
     .wrap { max-width: 1200px; margin: 0 auto; }
-    .grid { display: grid; gap: var(--gap); grid-template-columns: 1fr 420px; align-items: start; }
-    @media (max-width: 980px) { .grid { grid-template-columns: 1fr; } }
     .side { display: flex; flex-direction: column; gap: var(--gap); }
     .card {
       background: #fff;
@@ -186,7 +184,6 @@
     }
     .figureCanvas canvas { width: 100%; height: 100%; display: block; }
     @media (max-width: 720px) {
-      .grid { grid-template-columns: 1fr; }
       .figure-grid { --figure-columns: 1; }
       .figureCanvas { min-height: 280px; }
     }
@@ -274,7 +271,7 @@
 </head>
 <body>
   <div class="wrap">
-    <div class="grid">
+    <div class="grid layout--sidebar">
       <div class="card">
         <div id="figureGrid" class="figure-grid" data-figures="1">
           <div class="figure" data-figure-index="0">


### PR DESCRIPTION
## Summary
- add a shared `.layout--sidebar` helper in `base.css` with a default `--sidebar-width` and breakpoint handling for two-column pages
- update sidebar apps (arealmodell*, brøkpizza, brøkvegg, figurtall, fortegnsskjema, graftegner, kuler, kvikkbilder*, nkant, perlesnor, prikktilprikk, tallinje, tenkeblokker*, trefigurer, diagram) to consume the shared layout class and only override `--sidebar-width` when needed
- remove page-specific grid media queries that duplicated the shared responsive behavior

## Testing
- npm test *(fails: Playwright cannot launch browsers because required system libraries are missing in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e23af2215c8324b122fae695934863