### PR TITLE
Ensure uniform height for stacked tenkeblokker rows

### DIFF
--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -1099,8 +1099,13 @@ function draw(skipNormalization = false) {
     const height = DEFAULT_SVG_HEIGHT * BASE_INNER_RATIO / span;
     return Number.isFinite(height) && height > 0 ? height : DEFAULT_SVG_HEIGHT;
   });
+  const uniformRowHeight = rowHeights.reduce((max, value) => {
+    const numeric = Number(value);
+    if (!Number.isFinite(numeric) || numeric <= max) return max;
+    return numeric;
+  }, 0) || DEFAULT_SVG_HEIGHT;
   for (const block of visibleBlocks) {
-    const height = rowHeights[block.row];
+    const height = uniformRowHeight;
     if (block === null || block === void 0 ? void 0 : block.panel) {
       const numericHeight = Number.isFinite(height) && height > 0 ? height : DEFAULT_SVG_HEIGHT;
       block.panel.style.setProperty('--tb-svg-height', `${numericHeight.toFixed(2)}px`);


### PR DESCRIPTION
## Summary
- ensure stacked tenkeblokker panels share the same computed SVG height
- derive a uniform row height from existing calculations before applying to each block

## Testing
- npm start

------
https://chatgpt.com/codex/tasks/task_e_68e23e3dff008324a3ba58ab46ccaeba