### PR TITLE
Remove manual draw button from graph editor

### DIFF
--- a/graftegner.html
+++ b/graftegner.html
@@ -47,7 +47,6 @@
     .func-groups{ display:flex; flex-direction:column; gap:12px; width:100%; }
     .func-group{ display:flex; align-items:flex-start; gap:12px; }
     .func-group fieldset{ flex:1 1 auto; margin:0; }
-    .func-group .func-draw{ align-self:flex-start; }
     .func-group .func-fields{
       display:grid;
       gap:12px;
@@ -75,12 +74,6 @@
     .func-main .func-input{
       flex:1 1 auto;
       min-width:0;
-    }
-    .btn--inline-draw{
-      flex:0 0 auto;
-      white-space:nowrap;
-      min-height:42px;
-      padding-inline:16px;
     }
     .func-input .func-editor{
       display:flex;
@@ -167,12 +160,10 @@
     @media (max-width:680px){
       .function-controls{ align-items:stretch; }
       .func-group{ flex-direction:column; }
-      .func-group .func-draw{ width:100%; }
       .func-group .func-fields{ grid-template-columns:1fr; }
       .func-fields--first .func-row,
       .func-row--secondary{ grid-template-columns:1fr; }
       .func-main{ flex-direction:column; align-items:stretch; }
-      .btn--inline-draw{ width:100%; }
       .func-row--gliders{ grid-template-columns:1fr; }
     }
     .addFigureBtn{ width:clamp(36px,8vw,56px); aspect-ratio:1; border:2px dashed #cfcfcf; border-radius:10px; background:#fff; display:flex; align-items:center; justify-content:center; font-size:20px; color:#6b7280; cursor:pointer; transition:box-shadow .2s, transform .02s; }

--- a/graftegner.js
+++ b/graftegner.js
@@ -3091,7 +3091,6 @@ function setupSettingsForm() {
   const showBracketsInput = g('cfgShowBrackets');
   const forceTicksInput = g('cfgForceTicks');
   const snapCheckbox = g('cfgSnap');
-  const drawButtonSelector = '[data-action="draw"]';
   let gliderSection = null;
   let gliderCountInput = null;
   let gliderStartInput = null;
@@ -3823,9 +3822,6 @@ function setupSettingsForm() {
     row.className = 'func-group';
     row.dataset.index = String(index);
     const titleLabel = index === 1 ? 'Funksjon eller punkter' : 'Funksjon ' + index;
-    const drawButtonHtml = `
-      <button type="button" class="btn btn--inline-draw func-draw" data-action="draw" data-draw-index="${index}" aria-label="Tegn graf for funksjon ${index}">Tegn graf</button>
-    `;
     if (index === 1) {
       row.innerHTML = `
         <fieldset>
@@ -3871,7 +3867,6 @@ function setupSettingsForm() {
             </div>
           </div>
         </fieldset>
-        ${drawButtonHtml}
       `;
     } else {
       row.innerHTML = `
@@ -3894,7 +3889,6 @@ function setupSettingsForm() {
             </div>
           </div>
         </fieldset>
-        ${drawButtonHtml}
       `;
     }
     if (funcRows) {
@@ -4259,11 +4253,5 @@ function setupSettingsForm() {
   root.addEventListener('change', apply);
   root.addEventListener('keydown', e => {
     if (e.key === 'Enter') apply();
-  });
-  root.addEventListener('click', event => {
-    const trigger = event.target.closest(drawButtonSelector);
-    if (!trigger) return;
-    event.preventDefault();
-    apply();
   });
 }


### PR DESCRIPTION
## Summary
- remove the manual "Tegn graf" button from the graph editor's function rows
- clean up related event handling and styling that supported the button

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e24779b53c8324be52109d7f764577