### PR TITLE
Fix per-row SVG heights in Tenkeblokker

### DIFF
--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -1099,13 +1099,10 @@ function draw(skipNormalization = false) {
     const height = DEFAULT_SVG_HEIGHT * BASE_INNER_RATIO / span;
     return Number.isFinite(height) && height > 0 ? height : DEFAULT_SVG_HEIGHT;
   });
-  const uniformRowHeight = rowHeights.reduce((max, value) => {
-    const numeric = Number(value);
-    if (!Number.isFinite(numeric) || numeric <= max) return max;
-    return numeric;
-  }, 0) || DEFAULT_SVG_HEIGHT;
   for (const block of visibleBlocks) {
-    const height = uniformRowHeight;
+    const rowIndex = Number.isFinite(block === null || block === void 0 ? void 0 : block.row) ? Number(block.row) : 0;
+    const fallbackHeight = rowHeights[0] || DEFAULT_SVG_HEIGHT;
+    const height = rowHeights[rowIndex] || fallbackHeight;
     if (block === null || block === void 0 ? void 0 : block.panel) {
       const numericHeight = Number.isFinite(height) && height > 0 ? height : DEFAULT_SVG_HEIGHT;
       block.panel.style.setProperty('--tb-svg-height', `${numericHeight.toFixed(2)}px`);


### PR DESCRIPTION
## Summary
- use the precalculated height for each grid row instead of a shared maximum when updating the SVG height CSS variable
- ensure every block keeps its intended visual height regardless of position in the grid

## Testing
- Manual verification in browser

------
https://chatgpt.com/codex/tasks/task_e_68e24c348ffc8324b28b28e53d237bd4