### PR TITLE
Add app mode handling and task view styles

### DIFF
--- a/base.css
+++ b/base.css
@@ -379,6 +379,39 @@ select:disabled {
   resize: none;
 }
 
+body[data-app-mode="task"] .side {
+  gap: 0;
+}
+
+body[data-app-mode="task"] .side > :not(.card--examples),
+body[data-app-mode="task"] .card--settings,
+body[data-app-mode="task"] .card--export,
+body[data-app-mode="task"] .card:has(.alt-text) {
+  display: none !important;
+}
+
+body[data-app-mode="task"] .card--examples {
+  gap: 12px;
+}
+
+body[data-app-mode="task"] .card--examples .toolbar,
+body[data-app-mode="task"] .card--examples .example-tabs,
+body[data-app-mode="task"] .card--examples .example-settings {
+  display: none !important;
+}
+
+body[data-app-mode="task"] .card--examples .example-description {
+  gap: 10px;
+}
+
+body[data-app-mode="task"] .card--examples .example-description textarea {
+  min-height: 140px;
+}
+
+body[data-app-mode="task"] [data-export-button] {
+  display: none !important;
+}
+
 .form-row {
   display: grid;
   grid-template-columns: 1fr 1fr;

--- a/split.css
+++ b/split.css
@@ -31,6 +31,20 @@
   }
 }
 
+body[data-app-mode="task"] .grid.split-enabled {
+  grid-template-columns: minmax(0, 1fr) !important;
+  gap: var(--gap) !important;
+  --side-width: min(360px, 100%);
+}
+
+body[data-app-mode="task"] .grid.split-enabled > .splitter {
+  display: none !important;
+}
+
+body[data-app-mode="task"] .grid.split-enabled > .side {
+  width: min(360px, 100%);
+}
+
 /* Shared styling for settings panels */
 .card--settings fieldset,
 .card[data-card="settings"] fieldset {


### PR DESCRIPTION
## Summary
- add shared app mode coordination in `examples.js`, including query parsing, postMessage hooks, and exported helpers
- hide settings, export controls, and example tooling when `data-app-mode="task"` is active and collapse split layouts accordingly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e406cc35a08324be7dbf9dd584cd28