### PR TITLE
Align false dot-to-dot point colors with regular points

### DIFF
--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -279,15 +279,15 @@
       filter: drop-shadow(0 0 6px rgba(37, 99, 235, 0.55));
     }
     .point--false .point-dot {
-      fill: #b91c1c;
+      fill: #111827;
     }
     .point--false.point.is-selected .point-decoration {
-      fill: rgba(185, 28, 28, 0.18);
-      stroke: #b91c1c;
+      fill: rgba(37, 99, 235, 0.18);
+      stroke: #2563eb;
     }
     .point--false.point.is-selected .point-dot {
-      fill: #b91c1c;
-      filter: drop-shadow(0 0 6px rgba(185, 28, 28, 0.55));
+      fill: #2563eb;
+      filter: drop-shadow(0 0 6px rgba(37, 99, 235, 0.55));
     }
     .point-label {
       font-size: 16px;
@@ -299,7 +299,7 @@
       stroke-linejoin: round;
     }
     .point-label--false {
-      fill: #b91c1c;
+      fill: #111827;
     }
     .board-label-layer {
       position: absolute;
@@ -325,9 +325,9 @@
       pointer-events: auto;
     }
     .board-label--false {
-      color: #b91c1c;
-      background: rgba(254, 242, 242, .95);
-      box-shadow: 0 1px 3px rgba(185, 28, 28, .18);
+      color: #111827;
+      background: rgba(255, 255, 255, .92);
+      box-shadow: 0 1px 3px rgba(0,0,0,.12);
     }
     .board-label .katex { font-size: 1em; }
     .labels-hidden .board-label { display: none !important; }


### PR DESCRIPTION
## Summary
- make the false dot-to-dot point markers, labels, and tooltips reuse the default color styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e40e90ea4c83249b2fa54be347c0cc