### PR TITLE
Add campus-specific theme colors to graph and area tools

### DIFF
--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -28,10 +28,10 @@
     .settings .rect-row label { min-width: 0; }
     .settings .rect-row label.chk { justify-content: flex-start; align-items: center; }
 
-    .c1 { fill: #e07c7c; }
-    .c2 { fill: #f0c667; }
-    .c3 { fill: #7fb2d6; }
-    .c4 { fill: #8bb889; }
+    .c1 { fill: #2C395B; }
+    .c2 { fill: #E3B660; }
+    .c3 { fill: #F6E5BC; }
+    .c4 { fill: #E2DFF1; }
 
     .outer { fill: none; stroke: #333; stroke-width: 3.5; }
     .split { stroke: #333; stroke-width: 2.5; }


### PR DESCRIPTION
## Summary
- use the active theme profile in graftegner to choose curve colors and refresh them when the profile changes
- derive area-model rectangle fills from the theme palette and update the injected CSS when the theme switches
- adjust default area-model fallback colors to match the Campus profile palette

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e40df88cfc83248c310f026c7546dc