### PR TITLE
Hide add buttons in task mode

### DIFF
--- a/base.css
+++ b/base.css
@@ -129,6 +129,11 @@ body {
   padding: 20px;
 }
 
+[data-app-mode="task"] .addFigureBtn,
+[data-app-mode="task"] [data-edit-only] {
+  display: none !important;
+}
+
 .wrap {
   max-width: 1200px;
   margin: 0 auto;

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -151,11 +151,11 @@
         <div id="figureBoard" class="figure-board">
           <div id="figureGrid" class="figure-grid" data-cols="1"></div>
           <div class="figure-controls figure-controls--cols">
-            <button id="figAddColumn" class="addFigureBtn" type="button" aria-label="Legg til kolonne">+</button>
+            <button id="figAddColumn" class="addFigureBtn" type="button" aria-label="Legg til kolonne" data-edit-only>+</button>
             <button id="figRemoveColumn" class="addFigureBtn" type="button" aria-label="Fjern kolonne">−</button>
           </div>
           <div class="figure-controls figure-controls--rows">
-            <button id="figAddRow" class="addFigureBtn" type="button" aria-label="Legg til rad">+</button>
+            <button id="figAddRow" class="addFigureBtn" type="button" aria-label="Legg til rad" data-edit-only>+</button>
             <button id="figRemoveRow" class="addFigureBtn" type="button" aria-label="Fjern rad">−</button>
           </div>
         </div>

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -183,7 +183,7 @@
             <button id="removePizza3" class="btn removeFigureBtn" type="button" aria-label="Fjern figur">Fjern figur</button>
           </div>
 
-          <button id="addPizza" class="addFigureBtn" type="button" aria-label="Legg til pizza">+</button>
+          <button id="addPizza" class="addFigureBtn" type="button" aria-label="Legg til pizza" data-edit-only>+</button>
         </div>
       </div>
 

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -128,7 +128,7 @@
                 <input id="cfgAnswer2" type="text" value="">
               </label>
             </fieldset>
-            <button id="addSeries" class="addFigureBtn" type="button" aria-label="Legg til dataserie">+</button>
+            <button id="addSeries" class="addFigureBtn" type="button" aria-label="Legg til dataserie" data-edit-only>+</button>
           </div>
         </div>
 

--- a/figurtall.html
+++ b/figurtall.html
@@ -129,7 +129,7 @@
     <div class="grid layout--sidebar">
       <div class="card">
         <div id="figureContainer" class="grid2">
-          <button id="addFigure" class="addFigureBtn" type="button" aria-label="Legg til figur">+</button>
+          <button id="addFigure" class="addFigureBtn" type="button" aria-label="Legg til figur" data-edit-only>+</button>
         </div>
       </div>
       <div class="side">

--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -365,8 +365,8 @@
           <div id="chartOverlay" class="chart-overlay"></div>
         </div>
         <div class="figure-actions" aria-hidden="false">
-          <button type="button" class="figure-action" id="overlayAddPoint">Legg til nullpunkt</button>
-          <button type="button" class="figure-action" id="overlayAddRow">Legg til fortegnslinje</button>
+          <button type="button" class="figure-action" id="overlayAddPoint" data-edit-only>Legg til nullpunkt</button>
+          <button type="button" class="figure-action" id="overlayAddRow" data-edit-only>Legg til fortegnslinje</button>
         </div>
         <div class="toolbar">
           <div class="toolbar-row">
@@ -431,13 +431,13 @@
           <div class="card" style="padding: 12px; gap: 12px;">
             <h2>Punkter</h2>
             <div class="points-list" id="pointsList"></div>
-            <button class="btn" id="btnAddPoint">Legg til punkt</button>
+            <button class="btn" id="btnAddPoint" data-edit-only>Legg til punkt</button>
           </div>
 
           <div class="card" style="padding: 12px; gap: 12px;">
             <h2>Fortegnslinjer</h2>
             <div class="rows-list" id="rowsList"></div>
-            <button class="btn" id="btnAddRow">Legg til fortegnslinje</button>
+            <button class="btn" id="btnAddRow" data-edit-only>Legg til fortegnslinje</button>
           </div>
         </div>
 

--- a/graftegner.html
+++ b/graftegner.html
@@ -246,7 +246,7 @@
             <div class="function-controls">
               <div id="funcRows" class="func-groups"></div>
               <div class="func-actions">
-                <button id="addFunc" class="addFigureBtn" type="button" aria-label="Legg til funksjon">+</button>
+                <button id="addFunc" class="addFigureBtn" type="button" aria-label="Legg til funksjon" data-edit-only>+</button>
               </div>
             </div>
             <fieldset>

--- a/graftegner.js
+++ b/graftegner.js
@@ -3096,6 +3096,7 @@ function setupSettingsForm() {
   addBtn.type = 'button';
   addBtn.textContent = '+';
   addBtn.setAttribute('aria-label', 'Legg til funksjon');
+  addBtn.setAttribute('data-edit-only', '');
   addBtn.classList.remove('btn');
   addBtn.classList.add('addFigureBtn');
   const functionActions = document.querySelector('.func-actions');

--- a/kuler.html
+++ b/kuler.html
@@ -79,7 +79,7 @@
             </div>
             <button id="removeBowl4" class="btn removeFigureBtn" type="button" aria-label="Slett figur 4">Slett figur</button>
           </div>
-          <button id="addBowl" class="addFigureBtn" type="button" aria-label="Legg til illustrasjon">+</button>
+          <button id="addBowl" class="addFigureBtn" type="button" aria-label="Legg til illustrasjon" data-edit-only>+</button>
         </div>
       </div>
       <div class="side">

--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -401,14 +401,14 @@
             <legend>Punkter</legend>
             <div id="pointList" class="point-list"></div>
             <div class="toolbar toolbar--footer">
-              <button id="btnAddPoint" class="btn" type="button">Legg til</button>
+              <button id="btnAddPoint" class="btn" type="button" data-edit-only>Legg til</button>
             </div>
           </fieldset>
           <fieldset class="settings-section">
             <legend>Falske punkter</legend>
             <div id="falsePointList" class="point-list point-list--false"></div>
             <div class="toolbar toolbar--footer">
-              <button id="btnAddPointFalse" class="btn" type="button">Legg til</button>
+              <button id="btnAddPointFalse" class="btn" type="button" data-edit-only>Legg til</button>
             </div>
           </fieldset>
         </div>

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -28,7 +28,7 @@
       <div class="card">
         <div id="blocks" aria-label="Tenkeblokker"></div>
         <div class="toolbar">
-          <button id="addBlock" class="btn" type="button">Legg til blokk</button>
+          <button id="addBlock" class="btn" type="button" data-edit-only>Legg til blokk</button>
         </div>
       </div>
       <div class="side">

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -156,11 +156,11 @@
         <div id="tbBoard" class="tb-board">
           <div id="tbGrid" class="tb-grid" data-cols="1"></div>
           <div class="tb-controls tb-controls--cols">
-            <button id="tbAddColumn" class="addFigureBtn" type="button" aria-label="Legg til kolonne">+</button>
+            <button id="tbAddColumn" class="addFigureBtn" type="button" aria-label="Legg til kolonne" data-edit-only>+</button>
             <button id="tbRemoveColumn" class="addFigureBtn" type="button" aria-label="Fjern kolonne">−</button>
           </div>
           <div class="tb-controls tb-controls--rows">
-            <button id="tbAddRow" class="addFigureBtn" type="button" aria-label="Legg til rad">+</button>
+            <button id="tbAddRow" class="addFigureBtn" type="button" aria-label="Legg til rad" data-edit-only>+</button>
             <button id="tbRemoveRow" class="addFigureBtn" type="button" aria-label="Fjern rad">−</button>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- hide "Legg til" controls in task mode with a shared CSS rule
- mark add buttons across the apps as edit-only so they stay visible in edit mode
- ensure the dynamically generated graph add button follows the same visibility rule

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e4104fad088324ac850584309ba0a8