### PR TITLE
Fix regular polygon angle rendering

### DIFF
--- a/nkant.js
+++ b/nkant.js
@@ -2755,9 +2755,9 @@ function drawRegularPolygonToGroup(g, rect, spec, adv) {
     const mode = advAngles.mode && advAngles.mode[angleKey] ? advAngles.mode[angleKey] : advAngles.mode && advAngles.mode.default;
     if (!mode || String(mode).toLowerCase() === 'none') continue;
     const customText = advAngles.text && advAngles.text[angleKey] ? advAngles.text[angleKey] : deriveSequentialLabel(baseSideLabel, i, true);
-    const angleVal = angleAt(prev, cur, next);
+    const angleVal = angleAt(cur, prev, next);
     const parsed = parseAnglePointMode(mode, angleVal, customText, angleKey);
-    renderAngle(g, prev, cur, next, angleRadius(prev, cur, next), {
+    renderAngle(g, cur, prev, next, angleRadius(cur, prev, next), {
       mark: parsed.mark,
       angleText: parsed.angleText,
       pointLabel: parsed.pointLabel
@@ -2822,9 +2822,9 @@ function drawPolygonWithArcToGroup(g, rect, spec, adv, decorations) {
     const mode = advAngles.mode && advAngles.mode[angleKey] ? advAngles.mode[angleKey] : advAngles.mode && advAngles.mode.default;
     if (!mode || String(mode).toLowerCase() === 'none') continue;
     const customText = advAngles.text && advAngles.text[angleKey] ? advAngles.text[angleKey] : deriveSequentialLabel(baseSideLabel, i, true);
-    const angleVal = angleAt(prev, cur, next);
+    const angleVal = angleAt(cur, prev, next);
     const parsed = parseAnglePointMode(mode, angleVal, customText, angleKey);
-    renderAngle(g, prev, cur, next, angleRadius(prev, cur, next), {
+    renderAngle(g, cur, prev, next, angleRadius(cur, prev, next), {
       mark: parsed.mark,
       angleText: parsed.angleText,
       pointLabel: parsed.pointLabel


### PR DESCRIPTION
## Summary
- ensure regular polygon angle values are measured at the current vertex
- render polygon angle markers using the correct vertex so labels and highlights align with the figure

## Testing
- npm test *(fails: Playwright browsers require system dependencies in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68e50f3711b4832481750db5b9514e4f