### PR TITLE
Større uttrykkstekst for resultatraden

### DIFF
--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -59,6 +59,13 @@
       white-space: normal;
       word-break: break-word;
     }
+    .chart-labels__item--result {
+      font-size: 18px;
+      line-height: 1.3;
+    }
+    .chart-labels__item--result .katex {
+      font-size: 1.2em;
+    }
     .chart-labels__item .katex {
       font-size: 1em;
       white-space: normal;

--- a/fortegnsskjema.js
+++ b/fortegnsskjema.js
@@ -2049,7 +2049,7 @@
     }
     labels.forEach(info => {
       const item = document.createElement('div');
-      item.className = 'chart-labels__item';
+      item.className = typeof info.className === 'string' && info.className ? info.className : 'chart-labels__item';
       item.style.top = `${info.y}px`;
       labelsLayer.appendChild(item);
       renderRowLabelContent(item, info.text, info.preferMath);
@@ -2422,7 +2422,8 @@
       rowLabels.push({
         text: displayLabel,
         y,
-        preferMath: row.role === 'result' || row.role === 'factor' || !!row.locked
+        preferMath: row.role === 'result' || row.role === 'factor' || !!row.locked,
+        className: row.role === 'result' ? 'chart-labels__item chart-labels__item--result' : 'chart-labels__item'
       });
       const locked = chartLocked || row.locked || state.autoSync && row.role === 'result' && state.solution;
       const segments = row.segments;


### PR DESCRIPTION
## Summary
- enlarge the result row label styling so the displayed expression is easier to read
- tag the result row label in the renderer so the new styling is applied consistently

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e51d81af7c8324abcd0c07a9031762