### PR TITLE
Improve example storage resilience and serialization

### DIFF
--- a/tests/examples-fallback-storage.spec.js
+++ b/tests/examples-fallback-storage.spec.js
@@ -1,0 +1,58 @@
+const { test, expect } = require('@playwright/test');
+
+const STORAGE_KEY = 'examples_/graftegner';
+
+function createQuotaExceededError(page) {
+  return page.addInitScript(() => {
+    const createError = () => {
+      try {
+        return new DOMException('QuotaExceededError', 'QuotaExceededError');
+      } catch (error) {
+        const fallback = new Error('QuotaExceededError');
+        fallback.name = 'QuotaExceededError';
+        return fallback;
+      }
+    };
+    const quotaError = createError();
+    if (typeof Storage !== 'undefined' && Storage.prototype && typeof Storage.prototype.setItem === 'function') {
+      const original = Storage.prototype.setItem;
+      Storage.prototype.setItem = function patchedSetItem() {
+        throw quotaError;
+      };
+      if (!window.__RESTORE_STORAGE_SETITEM__) {
+        window.__RESTORE_STORAGE_SETITEM__ = () => {
+          Storage.prototype.setItem = original;
+        };
+      }
+    }
+  });
+}
+
+test.describe('Example storage fallback', () => {
+  test('falls back to in-memory storage with notice when quota is exceeded', async ({ page }) => {
+    await createQuotaExceededError(page);
+
+    await page.goto('/graftegner.html', { waitUntil: 'load' });
+
+    await page.locator('#btnSaveExample').click();
+
+    const notice = page.locator('.example-storage-notice');
+    await expect(notice).toBeVisible();
+    await expect(notice).toContainText(/lagres midlertidig/i);
+
+    const fallbackMode = await page.evaluate(() => window.__EXAMPLES_FALLBACK_STORAGE_MODE__);
+    expect(fallbackMode).toBe('memory');
+
+    const stored = await page.evaluate(key => {
+      const store = window.__EXAMPLES_FALLBACK_STORAGE__;
+      if (!store || typeof store.getItem !== 'function') return null;
+      try {
+        return store.getItem(key);
+      } catch (error) {
+        return null;
+      }
+    }, STORAGE_KEY);
+
+    expect(stored).not.toBeNull();
+  });
+});

--- a/tests/examples-store.spec.js
+++ b/tests/examples-store.spec.js
@@ -1,0 +1,52 @@
+const { test, expect } = require('@playwright/test');
+
+const {
+  setEntry,
+  getEntry,
+  deleteEntry,
+  __deserializeExampleValue
+} = require('../api/_lib/examples-store');
+
+function buildPath() {
+  return `/serialization-test-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+}
+
+test.describe('examples-store serialization', () => {
+  test('round-trips Map and Set data', async () => {
+    const path = buildPath();
+    const shapes = new Map();
+    shapes.set('alpha', new Set(['a', 'b']));
+    shapes.set('beta', new Set(['c']));
+
+    const payload = {
+      examples: [
+        {
+          description: 'Map/Set example',
+          config: {
+            STATE: {
+              shapes
+            }
+          }
+        }
+      ]
+    };
+
+    const entry = await setEntry(path, payload);
+    expect(Array.isArray(entry.examples)).toBe(true);
+    const encoded = entry.examples[0].config.STATE.shapes;
+    expect(encoded).toHaveProperty('__mathVisualsType__', 'map');
+
+    const stored = await getEntry(path);
+    expect(stored).not.toBeNull();
+    const decoded = __deserializeExampleValue(stored.examples[0].config.STATE.shapes);
+    expect(decoded instanceof Map).toBe(true);
+    const roundTrip = Array.from(decoded.entries()).map(([key, set]) => [key, Array.from(set).sort()]);
+    roundTrip.sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0));
+    expect(roundTrip).toEqual([
+      ['alpha', ['a', 'b']],
+      ['beta', ['c']]
+    ]);
+
+    await deleteEntry(path);
+  });
+});


### PR DESCRIPTION
## Summary
- harden the example storage wrapper to fall back to memory when both localStorage and sessionStorage fail, and surface a UI notice when persistence is temporary
- preserve Map/Set and other non-JSON structures in example payloads on both the frontend and backend, including new helpers and regression coverage
- add Playwright and backend tests covering serialization round-trips and fallback behaviour

## Testing
- `npm test` *(fails: browser dependencies missing in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e5228458408324aa2823afc836a9eb