### PR TITLE
Fix Playwright CDN download failures in CI

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "arealmodell0.js",
   "scripts": {
     "pretest": "node scripts/ensure-playwright-deps.js",
-    "test": "node tests/check-shared-styles.js && playwright test",
+    "test": "node tests/check-shared-styles.js && node scripts/run-playwright.js test",
     "start": "npx http-server -c-1"
   },
   "keywords": [],

--- a/scripts/ensure-playwright-deps.js
+++ b/scripts/ensure-playwright-deps.js
@@ -24,7 +24,15 @@ if (process.getuid && process.getuid() !== 0) {
   process.exit(1);
 }
 
-const result = spawnSync('npx', ['playwright', 'install-deps'], { stdio: 'inherit' });
+const env = { ...process.env };
+if (!env.PLAYWRIGHT_DOWNLOAD_HOST) {
+  env.PLAYWRIGHT_DOWNLOAD_HOST = 'https://playwright.azureedge.net';
+}
+
+const result = spawnSync('npx', ['playwright', 'install-deps'], {
+  stdio: 'inherit',
+  env,
+});
 if (result.status !== 0) {
   console.error('[playwright] Failed to install system dependencies automatically.');
   console.error('Please run `npx playwright install-deps` manually to review the error output.');

--- a/scripts/run-playwright.js
+++ b/scripts/run-playwright.js
@@ -1,0 +1,18 @@
+#!/usr/bin/env node
+const { spawnSync } = require('child_process');
+
+const cli = require.resolve('@playwright/test/cli');
+const env = { ...process.env };
+if (!env.PLAYWRIGHT_DOWNLOAD_HOST) {
+  env.PLAYWRIGHT_DOWNLOAD_HOST = 'https://playwright.azureedge.net';
+}
+
+const result = spawnSync(process.execPath, [cli, ...process.argv.slice(2)], {
+  stdio: 'inherit',
+  env,
+});
+
+if (result.error) {
+  throw result.error;
+}
+process.exit(result.status ?? 1);


### PR DESCRIPTION
## Summary
- ensure Playwright installs and tests default to the Azure CDN mirror when no download host is configured
- add a wrapper script that sets the download host before invoking the Playwright CLI

## Testing
- npm test *(fails: Shared styling check failed: examples-trash.html missing required layout wrappers)*

------
https://chatgpt.com/codex/tasks/task_e_68e54d01696c83248a13e16380d4ecee