### PR TITLE
Ensure backend examples keep provided defaults

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -1073,6 +1073,19 @@
       let examples = data && Array.isArray(data.examples) ? data.examples.map(example => example && typeof example === 'object' ? { ...example } : example) : [];
       const providedDefaults = getProvidedExamples();
       if (Array.isArray(providedDefaults) && providedDefaults.length) {
+        const deletedProvidedSet = new Set();
+        const backendDeleted = data && Array.isArray(data.deletedProvided) ? data.deletedProvided : [];
+        backendDeleted.forEach(value => {
+          const key = normalizeKey(value);
+          if (key) deletedProvidedSet.add(key);
+        });
+        const localDeleted = getDeletedProvidedExamples();
+        if (localDeleted && localDeleted.size) {
+          localDeleted.forEach(value => {
+            const key = normalizeKey(value);
+            if (key) deletedProvidedSet.add(key);
+          });
+        }
         const existingKeys = new Set();
         examples.forEach(ex => {
           const key = normalizeKey(ex && ex.__builtinKey);
@@ -1081,7 +1094,7 @@
         providedDefaults.forEach(ex => {
           if (!ex || typeof ex !== 'object') return;
           const key = normalizeKey(ex.__builtinKey);
-          if (key && existingKeys.has(key)) return;
+          if (key && (existingKeys.has(key) || deletedProvidedSet.has(key))) return;
           const copy = {
             config: cloneValue(ex.config),
             svg: typeof ex.svg === 'string' ? ex.svg : ''


### PR DESCRIPTION
## Summary
- ensure backend-loaded example lists re-add any missing provided Graftegner defaults before persisting them locally
- prevent defaults marked as deleted from being reintroduced during backend sync

## Testing
- n/a (environment prevents running Playwright tests)


------
https://chatgpt.com/codex/tasks/task_e_68e58e9fbd9c8324b9dc72a71b61ab83