### PR TITLE
Prefer custom Graftegner examples on initial load

### DIFF
--- a/examples.js
+++ b/examples.js
@@ -3173,6 +3173,16 @@
         if (!initialLoadPerformed && refreshed.length > 0) {
           let targetIndex = Number.isInteger(currentExampleIndex) ? currentExampleIndex : NaN;
           if (!Number.isInteger(targetIndex) || targetIndex < 0 || targetIndex >= refreshed.length) {
+            const firstCustomIndex = refreshed.findIndex(example => {
+              if (!example || typeof example !== 'object') return false;
+              const key = normalizeKey(example.__builtinKey);
+              return !key;
+            });
+            if (Number.isInteger(firstCustomIndex) && firstCustomIndex >= 0) {
+              targetIndex = firstCustomIndex;
+            }
+          }
+          if (!Number.isInteger(targetIndex) || targetIndex < 0 || targetIndex >= refreshed.length) {
             targetIndex = refreshed.findIndex(ex => ex && ex.isDefault === true);
           }
           if (!Number.isInteger(targetIndex) || targetIndex < 0 || targetIndex >= refreshed.length) {


### PR DESCRIPTION
## Summary
- prioritize user-saved Graftegner examples when determining which example to load on startup
- fall back to built-in defaults only if no custom examples exist or none are valid

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e60ce8e5508324934287cd19d2d04a