### PR TITLE
Fix Playwright dependency validation import

### DIFF
--- a/scripts/ensure-playwright-deps.js
+++ b/scripts/ensure-playwright-deps.js
@@ -13,14 +13,13 @@ async function markInstalled() {
 
 async function validateDependencies() {
   try {
-    const { registry } = require('playwright-core/lib/server/registry');
-    const { getEmbedderName } = require('playwright-core/lib/server/utils/userAgent');
+    const { registry } = require('playwright-core/lib/server');
     const executables = registry.defaultExecutables();
     if (!executables.length) {
       return { ok: true };
     }
-    const { embedderName } = getEmbedderName();
-    await registry.validateHostRequirementsForExecutablesIfNeeded(executables, embedderName);
+    const sdkLanguage = process.env.PW_LANG_NAME || 'javascript';
+    await registry.validateHostRequirementsForExecutablesIfNeeded(executables, sdkLanguage);
     return { ok: true };
   } catch (error) {
     return { ok: false, error };


### PR DESCRIPTION
## Summary
- switch the dependency validation helper to use the public `playwright-core/lib/server` entry point
- reuse Playwright's SDK language environment variable when validating host requirements

## Testing
- not run (node executable is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e5936517ec83249914428acd967a4e