### PR TITLE
Align trash archive layout with shared styling checks

### DIFF
--- a/examples-trash.html
+++ b/examples-trash.html
@@ -17,7 +17,10 @@
       min-height: 100vh;
       min-height: 100dvh;
     }
-    main {
+    .trash-layout {
+      justify-content: center;
+    }
+    .trash-page {
       max-width: 960px;
       margin: 0 auto;
       padding: 32px 20px 48px;
@@ -270,7 +273,7 @@
       letter-spacing: 0.05em;
     }
     @media (max-width: 640px) {
-      main {
+      .trash-page {
         padding: 24px 14px 36px;
       }
       .trash-group {
@@ -280,9 +283,9 @@
   </style>
 </head>
 <body>
-  <div class="wrap">
-    <div class="grid">
-      <main>
+  <div class="wrap wrap--trash">
+    <div class="grid layout--full trash-layout">
+      <main class="trash-page">
         <header class="trash-header">
           <h1 class="trash-header__title">Arkiv for eksempler</h1>
           <p class="trash-header__description">


### PR DESCRIPTION
## Summary
- wrap the trash archive page content in the shared `.wrap`/`.grid` layout containers
- scope the page styling through a dedicated `.trash-page` wrapper to satisfy the shared layout check

## Testing
- npm test *(fails: Playwright browsers cannot be downloaded in this environment — HTTP 403)*

------
https://chatgpt.com/codex/tasks/task_e_68e6299debf48324930d25b968b854db