### PR TITLE
Add disk fallback for examples store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 playwright-report/
 test-results/
 .cache/
+.data/

--- a/api/_lib/examples-store.js
+++ b/api/_lib/examples-store.js
@@ -1,5 +1,8 @@
 'use strict';
 
+const nodePath = require('path');
+const fsPromises = require('fs/promises');
+
 const KEY_PREFIX = 'examples:';
 const INDEX_KEY = 'examples:__paths__';
 
@@ -16,6 +19,17 @@ const memoryIndex = globalScope.__EXAMPLES_MEMORY_INDEX__;
 
 let kvClientPromise = null;
 let kvConfigWarningLogged = false;
+
+const FALLBACK_DATA_DIR = process.env.EXAMPLES_FALLBACK_DIR
+  ? nodePath.resolve(process.cwd(), process.env.EXAMPLES_FALLBACK_DIR)
+  : nodePath.join(process.cwd(), '.data');
+const FALLBACK_DATA_FILE = process.env.EXAMPLES_FALLBACK_FILE
+  ? nodePath.resolve(process.cwd(), process.env.EXAMPLES_FALLBACK_FILE)
+  : nodePath.join(FALLBACK_DATA_DIR, 'examples-store.json');
+
+let fallbackStoreLoaded = false;
+let fallbackStoreLoading = null;
+let fallbackPersistenceEnabled = true;
 
 const EXAMPLE_VALUE_TYPE_KEY = '__mathVisualsType__';
 const EXAMPLE_VALUE_DATA_KEY = '__mathVisualsValue__';
@@ -175,6 +189,11 @@ function isKvConfigured() {
   return Boolean(process.env.KV_REST_API_URL && process.env.KV_REST_API_TOKEN);
 }
 
+function getStoreMode() {
+  if (isKvConfigured()) return 'kv';
+  return fallbackPersistenceEnabled ? 'file' : 'memory';
+}
+
 async function loadKvClient() {
   if (!isKvConfigured()) {
     if (!kvConfigWarningLogged) {
@@ -187,6 +206,109 @@ async function loadKvClient() {
     kvClientPromise = import('@vercel/kv').then(mod => mod && mod.kv ? mod.kv : null).catch(() => null);
   }
   return kvClientPromise;
+}
+
+async function ensureFallbackDirectoryExists() {
+  if (!fallbackPersistenceEnabled) return false;
+  try {
+    await fsPromises.mkdir(nodePath.dirname(FALLBACK_DATA_FILE), { recursive: true });
+    return true;
+  } catch (error) {
+    fallbackPersistenceEnabled = false;
+    console.warn('[examples-store] Failed to create fallback data directory', {
+      path: FALLBACK_DATA_FILE,
+      error
+    });
+    return false;
+  }
+}
+
+async function loadFallbackStore() {
+  if (fallbackStoreLoaded || !fallbackPersistenceEnabled) return;
+  if (!fallbackStoreLoading) {
+    fallbackStoreLoading = (async () => {
+      try {
+        const raw = await fsPromises.readFile(FALLBACK_DATA_FILE, 'utf8');
+        let parsed = null;
+        try {
+          parsed = JSON.parse(raw);
+        } catch (error) {
+          console.warn('[examples-store] Failed to parse fallback data file', {
+            path: FALLBACK_DATA_FILE,
+            error
+          });
+          parsed = null;
+        }
+        if (parsed && Array.isArray(parsed.entries)) {
+          memoryStore.clear();
+          memoryIndex.clear();
+          parsed.entries.forEach(item => {
+            if (!item || typeof item !== 'object') return;
+            const normalized = normalizePath(item.path);
+            if (!normalized) return;
+            const entry = buildEntry(normalized, item);
+            entry.storage = 'file';
+            writeToMemory(normalized, entry);
+          });
+        }
+      } catch (error) {
+        if (error && error.code === 'ENOENT') {
+          // Missing file is fine; nothing to load yet.
+        } else {
+          fallbackPersistenceEnabled = false;
+          console.warn('[examples-store] Failed to read fallback data file', {
+            path: FALLBACK_DATA_FILE,
+            error
+          });
+        }
+      } finally {
+        fallbackStoreLoaded = true;
+        fallbackStoreLoading = null;
+      }
+    })();
+  }
+  return fallbackStoreLoading;
+}
+
+async function ensureFallbackLoaded() {
+  if (isKvConfigured()) return;
+  await loadFallbackStore();
+}
+
+async function persistFallbackStore() {
+  if (isKvConfigured() || !fallbackPersistenceEnabled) {
+    return false;
+  }
+  const dirReady = await ensureFallbackDirectoryExists();
+  if (!dirReady) {
+    return false;
+  }
+  const entries = [];
+  memoryIndex.forEach(pathValue => {
+    const normalized = normalizePath(pathValue);
+    if (!normalized) return;
+    const stored = readFromMemory(normalized);
+    if (!stored) return;
+    const cloneValue = clone(stored);
+    cloneValue.storage = 'file';
+    entries.push(cloneValue);
+  });
+  const payload = {
+    version: 1,
+    updatedAt: new Date().toISOString(),
+    entries
+  };
+  try {
+    await fsPromises.writeFile(FALLBACK_DATA_FILE, JSON.stringify(payload, null, 2), 'utf8');
+    return true;
+  } catch (error) {
+    fallbackPersistenceEnabled = false;
+    console.warn('[examples-store] Failed to persist fallback data file', {
+      path: FALLBACK_DATA_FILE,
+      error
+    });
+    return false;
+  }
 }
 
 function normalizePath(value) {
@@ -329,6 +451,7 @@ function readFromMemory(path) {
 async function getEntry(path) {
   const normalized = normalizePath(path);
   if (!normalized) return null;
+  await ensureFallbackLoaded();
   const kvValue = await readFromKv(normalized);
   if (kvValue) {
     const entry = buildEntry(normalized, kvValue);
@@ -348,30 +471,45 @@ async function getEntry(path) {
 async function setEntry(path, payload) {
   const normalized = normalizePath(path);
   if (!normalized) return null;
+  await ensureFallbackLoaded();
   const entry = buildEntry(normalized, payload || {});
   const result = await writeToKv(normalized, entry);
   if (!result || result.reason === 'error') {
     throw new KvOperationError('Failed to write entry to KV', { cause: result && result.error });
   }
+  if (result && result.ok) {
+    entry.storage = 'kv';
+    writeToMemory(normalized, entry);
+    return clone(entry);
+  }
+  entry.storage = 'file';
   writeToMemory(normalized, entry);
-  const output = clone(entry);
-  output.storage = result && result.ok ? 'kv' : 'memory';
-  return output;
+  const persisted = await persistFallbackStore();
+  if (!persisted) {
+    entry.storage = 'memory';
+    writeToMemory(normalized, entry);
+  }
+  return clone(entry);
 }
 
 async function deleteEntry(path) {
   const normalized = normalizePath(path);
   if (!normalized) return false;
+  await ensureFallbackLoaded();
   const result = await deleteFromKv(normalized);
   if (!result || result.reason === 'error') {
     throw new KvOperationError('Failed to delete entry in KV', { cause: result && result.error });
   }
   deleteFromMemory(normalized);
+  if (!result.ok) {
+    await persistFallbackStore();
+  }
   return true;
 }
 
 async function listEntries() {
   const kv = await loadKvClient();
+  await ensureFallbackLoaded();
   const entries = [];
   if (kv) {
     let paths = [];
@@ -413,6 +551,7 @@ module.exports = {
   listEntries,
   KvOperationError,
   isKvConfigured,
+  getStoreMode,
   __serializeExampleValue: value => serializeExampleValue(value, new WeakMap()),
   __deserializeExampleValue: value => deserializeExampleValue(value, new WeakMap())
 };

--- a/api/examples/index.js
+++ b/api/examples/index.js
@@ -8,7 +8,7 @@ const {
   deleteEntry,
   listEntries,
   KvOperationError,
-  isKvConfigured
+  getStoreMode
 } = require('../_lib/examples-store');
 
 function parseAllowedOrigins() {
@@ -85,7 +85,7 @@ module.exports = async function handler(req, res) {
     res.setHeader('Vary', 'Origin');
   }
 
-  res.setHeader('X-Examples-Store-Mode', isKvConfigured() ? 'kv' : 'memory');
+  res.setHeader('X-Examples-Store-Mode', getStoreMode());
 
   if (req.method === 'OPTIONS') {
     res.statusCode = 204;
@@ -126,7 +126,7 @@ module.exports = async function handler(req, res) {
         return;
       }
       await deleteEntry(target);
-      res.setHeader('X-Examples-Storage-Result', isKvConfigured() ? 'kv' : 'memory');
+      res.setHeader('X-Examples-Storage-Result', getStoreMode());
       sendJson(res, 200, { ok: true });
       return;
     }


### PR DESCRIPTION
## Summary
- add a filesystem-backed persistence layer when KV is not configured for the examples store
- expose the active storage mode so the API can report when the fallback file store is in use
- ignore the local .data directory that holds the persisted examples JSON file

## Testing
- not run (Playwright dependencies attempted to install and the run was cancelled)

------
https://chatgpt.com/codex/tasks/task_e_68e6314f15188324b1497699623431f0