### PR TITLE
Shorten example management button labels

### DIFF
--- a/arealmodell.html
+++ b/arealmodell.html
@@ -52,9 +52,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/arealmodell0.html
+++ b/arealmodell0.html
@@ -38,9 +38,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/arealmodellen1.html
+++ b/arealmodellen1.html
@@ -60,9 +60,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/brøkfigurer.html
+++ b/brøkfigurer.html
@@ -167,9 +167,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/brøkpizza.html
+++ b/brøkpizza.html
@@ -194,9 +194,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
 

--- a/brøkvegg.html
+++ b/brøkvegg.html
@@ -185,9 +185,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
 

--- a/diagram/index.html
+++ b/diagram/index.html
@@ -48,9 +48,9 @@
             </div>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
 

--- a/figurtall.html
+++ b/figurtall.html
@@ -140,9 +140,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/fortegnsskjema.html
+++ b/fortegnsskjema.html
@@ -400,9 +400,9 @@
             </div>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
 

--- a/graftegner.html
+++ b/graftegner.html
@@ -245,9 +245,9 @@
             <div id="checkArea" class="checkbar" data-task-check-host hidden></div>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
 

--- a/kuler.html
+++ b/kuler.html
@@ -89,9 +89,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/kvikkbilder-monster.html
+++ b/kvikkbilder-monster.html
@@ -82,9 +82,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/kvikkbilder.html
+++ b/kvikkbilder.html
@@ -116,9 +116,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/nkant.html
+++ b/nkant.html
@@ -86,9 +86,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
 

--- a/perlesnor.html
+++ b/perlesnor.html
@@ -48,9 +48,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
 

--- a/prikktilprikk.html
+++ b/prikktilprikk.html
@@ -420,9 +420,9 @@
             </div>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/tallinje.html
+++ b/tallinje.html
@@ -182,9 +182,9 @@
           </div>
           <div class="toolbar">
             <span class="badge badge--beta" aria-label="Tallinje er i betaversjon">Beta</span>
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
 

--- a/tenkeblokker-stepper.html
+++ b/tenkeblokker-stepper.html
@@ -38,9 +38,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
         <div class="card card--settings">

--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -172,9 +172,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
         <div class="card" id="exportCard">

--- a/trefigurer.html
+++ b/trefigurer.html
@@ -224,9 +224,9 @@
             <textarea id="exampleDescription" placeholder="Skriv en oppgavetekst som lagres med eksemplet"></textarea>
           </div>
           <div class="toolbar">
-            <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
-            <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
-            <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>
+            <button id="btnUpdateExample" class="btn" type="button">Oppdater</button>
+            <button id="btnSaveExample" class="btn" type="button">Lag nytt</button>
+            <button id="btnDeleteExample" class="btn" type="button">Arkiver</button>
           </div>
         </div>
         <div id="exportCard" class="card card--export">


### PR DESCRIPTION
## Summary
- shorten the example toolbar button labels across the applications to use "Oppdater", "Lag nytt", and "Arkiver" so they align better side by side

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e639641cbc8324a37d523c02ad750b