### PR TITLE
Ensure global settings checkboxes precede labels

### DIFF
--- a/split.css
+++ b/split.css
@@ -98,6 +98,11 @@ body[data-app-mode="task"] .grid.split-enabled {
   gap: 8px;
 }
 
+.card--settings label.checkbox input,
+.card[data-card="settings"] label.checkbox input {
+  order: -1;
+}
+
 .card--settings .settings-divider,
 .card[data-card="settings"] .settings-divider {
   height: 10px;


### PR DESCRIPTION
## Summary
- force settings panel checkboxes to render before their descriptions by adjusting flex order

## Testing
- no automated tests run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68e63aad98a88324bbd409a327cf5a33