### PR TITLE
Remove Tallinje beta badge from toolbar

### DIFF
--- a/tallinje.html
+++ b/tallinje.html
@@ -54,21 +54,6 @@
       justify-content: center;
       width: 100%;
     }
-    .badge {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      padding: 4px 10px;
-      border-radius: 999px;
-      font-size: 12px;
-      font-weight: 600;
-      letter-spacing: 0.02em;
-    }
-    .badge--beta {
-      background: #6366f1;
-      color: #fff;
-      text-transform: uppercase;
-    }
     .draggable-item { cursor: grab; touch-action: none; }
     .draggable-item.is-placed .draggable-item__bg { fill: #eef2ff; }
     .draggable-item.is-dragging, .draggable-item:active { cursor: grabbing; }
@@ -181,7 +166,6 @@
             </div>
           </div>
           <div class="toolbar">
-            <span class="badge badge--beta" aria-label="Tallinje er i betaversjon">Beta</span>
             <button id="btnUpdateExample" class="btn" type="button">Oppdater eksempel</button>
             <button id="btnSaveExample" class="btn" type="button">Lag nytt eksempel</button>
             <button id="btnDeleteExample" class="btn" type="button">Arkiver eksempel</button>


### PR DESCRIPTION
## Summary
- remove the Tallinje toolbar beta badge and associated styling so the actions row only displays the example controls

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e63b2f05288324a71e6ddfcdc3be70