### PR TITLE
Add conditional left padding for Tenkeblokker row labels

### DIFF
--- a/tenkeblokker.html
+++ b/tenkeblokker.html
@@ -25,6 +25,7 @@
     }
     .tb-grid{
       --tb-label-max-width:0px;
+      --tb-grid-padding-left:28px;
       grid-column:1;
       grid-row:1;
       display:flex;
@@ -32,7 +33,7 @@
       gap:0;
       row-gap:0;
       column-gap:0;
-      padding:var(--tb-grid-padding-top,20px) 18px 18px 28px;
+      padding:var(--tb-grid-padding-top,20px) 18px 18px var(--tb-grid-padding-left,28px);
       width:100%;
       align-items:flex-start;
       overflow:visible;

--- a/tenkeblokker.js
+++ b/tenkeblokker.js
@@ -162,6 +162,9 @@ const ROW_GAP = 18;
 const ROW_LABEL_GAP = 18;
 const DEFAULT_FRAME_INSET = 3;
 const DEFAULT_GRID_PADDING_TOP = 20;
+const DEFAULT_GRID_PADDING_LEFT = 28;
+const ROW_LABEL_EXTRA_LEFT_PADDING = 100;
+const ROW_LABEL_EXTRA_PADDING_ROWS = 3;
 const COMBINED_WHOLE_TOP_MARGIN = 12;
 const BLOCKS = [];
 let multipleBlocksActive = false;
@@ -979,9 +982,11 @@ function draw(skipNormalization = false) {
     });
   }
   let maxLabelWidth = 0;
+  let needsFrontPadding = false;
   if (grid) {
     grid.style.setProperty('--tb-row-label-gap', `${ROW_LABEL_GAP}px`);
     grid.style.setProperty('--tb-label-max-width', '0px');
+    grid.style.setProperty('--tb-grid-padding-left', `${DEFAULT_GRID_PADDING_LEFT}px`);
   }
   ROW_LABEL_ELEMENTS.forEach((label, index) => {
     if (!label) return;
@@ -999,6 +1004,9 @@ function draw(skipNormalization = false) {
       const measured = measureRowLabelWidth(trimmed);
       const padded = Math.ceil(Number.isFinite(measured) ? measured : 0) + ROW_LABEL_GAP;
       if (padded > maxLabelWidth) maxLabelWidth = padded;
+      if (!needsFrontPadding && index < ROW_LABEL_EXTRA_PADDING_ROWS) {
+        needsFrontPadding = true;
+      }
     } else {
       label.style.display = 'none';
     }
@@ -1006,6 +1014,10 @@ function draw(skipNormalization = false) {
   if (grid) {
     const safeMax = Math.max(0, Math.ceil(maxLabelWidth));
     grid.style.setProperty('--tb-label-max-width', `${safeMax}px`);
+    if (needsFrontPadding) {
+      const paddingLeft = DEFAULT_GRID_PADDING_LEFT + ROW_LABEL_EXTRA_LEFT_PADDING;
+      grid.style.setProperty('--tb-grid-padding-left', `${paddingLeft}px`);
+    }
   }
   const rowTotals = Array.from({
     length: CONFIG.rows


### PR DESCRIPTION
## Summary
- add a CSS variable for the grid's left padding in the Tenkeblokker view
- update the draw routine to expand the left padding by 100px when any of the first three row labels have content

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e63d8d7c1c832498edd29a4e821021