### PR TITLE
Fix Campus profile side text contrast

### DIFF
--- a/nkant.js
+++ b/nkant.js
@@ -592,9 +592,9 @@ const STYLE_PROFILE_OVERRIDES = {
     edgeStroke: "#2C395B",
     angStroke: "#ffffff",
     angFill: "rgba(255, 255, 255, 0.9)",
-    textFill: "#2C395B",
-    textHalo: null,
-    textHaloW: 0,
+    textFill: "#ffffff",
+    textHalo: "#2C395B",
+    textHaloW: 5,
     constructionStroke: "#ffffff",
     constructionWidth: 4,
     constructionDash: "6 6"


### PR DESCRIPTION
## Summary
- update the Campus theme overrides for nkant so side labels render with high contrast

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6529361e08324811b4af4a9cad32e