### PR TITLE
Ensure default examples include explicit example1 route

### DIFF
--- a/index.html
+++ b/index.html
@@ -531,7 +531,14 @@
         </a>
       </li>
       <li>
-        <a href="nkant.html" target="content" data-label="nKant" aria-label="nKant">
+        <a
+          href="nkant.html"
+          target="content"
+          data-label="nKant"
+          aria-label="nKant"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <polygon stroke-linejoin="round" points="12 4 20 20 4 20" />
           </svg>
@@ -539,7 +546,14 @@
         </a>
       </li>
       <li>
-        <a href="diagram/index.html" target="content" data-label="Diagram" aria-label="Diagram">
+        <a
+          href="diagram/index.html"
+          target="content"
+          data-label="Diagram"
+          aria-label="Diagram"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 13.125C3 12.504 3.504 12 4.125 12h2.25c.621 0 1.125.504 1.125 1.125v6.75C7.5 20.496 6.996 21 6.375 21h-2.25A1.125 1.125 0 0 1 3 19.875v-6.75Z" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M9.75 8.625c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125v11.25c0 .621-.504 1.125-1.125 1.125h-2.25a1.125 1.125 0 0 1-1.125-1.125V8.625Z" />
@@ -549,7 +563,14 @@
         </a>
       </li>
       <li>
-        <a href="brøkpizza.html" target="content" data-label="Brøkpizza" aria-label="Brøkpizza">
+        <a
+          href="brøkpizza.html"
+          target="content"
+          data-label="Brøkpizza"
+          aria-label="Brøkpizza"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M10.5 6a7.5 7.5 0 1 0 7.5 7.5h-7.5V6Z" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M13.5 10.5H21A7.5 7.5 0 0 0 13.5 3v7.5Z" />
@@ -558,7 +579,14 @@
         </a>
       </li>
       <li>
-        <a href="brøkfigurer.html" target="content" data-label="Brøkfigurer" aria-label="Brøkfigurer">
+        <a
+          href="brøkfigurer.html"
+          target="content"
+          data-label="Brøkfigurer"
+          aria-label="Brøkfigurer"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <polygon points="4 20 12 20 12 4" fill="currentColor" />
             <polygon points="4 20 20 20 12 4" />
@@ -568,7 +596,14 @@
         </a>
       </li>
       <li>
-        <a href="figurtall.html" target="content" data-label="Figurtall" aria-label="Figurtall">
+        <a
+          href="figurtall.html"
+          target="content"
+          data-label="Figurtall"
+          aria-label="Figurtall"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <rect x="3" y="15" width="6" height="6" fill="currentColor" stroke="none" />
             <rect x="9" y="9" width="6" height="6" fill="currentColor" stroke="none" />
@@ -581,7 +616,14 @@
         </a>
       </li>
       <li>
-        <a href="tenkeblokker.html" target="content" data-label="Tenkeblokker" aria-label="Tenkeblokker">
+        <a
+          href="tenkeblokker.html"
+          target="content"
+          data-label="Tenkeblokker"
+          aria-label="Tenkeblokker"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 40" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <line x1="0" y1="5" x2="100" y2="5" stroke-linecap="round" />
             <rect x="0" y="10" width="100" height="25" fill="currentColor" stroke="none" />
@@ -590,7 +632,14 @@
         </a>
       </li>
       <li>
-        <a href="arealmodell.html" target="content" data-label="Arealmodell" aria-label="Arealmodell">
+        <a
+          href="arealmodell.html"
+          target="content"
+          data-label="Arealmodell"
+          aria-label="Arealmodell"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <rect x="4" y="5" width="16" height="14" rx="1.8" stroke="currentColor" stroke-width="1.4" />
             <rect x="4.5" y="5.5" width="7" height="6" fill="currentColor" fill-opacity=".15" stroke="none" />
@@ -604,7 +653,14 @@
         </a>
       </li>
       <li>
-        <a href="perlesnor.html" target="content" data-label="Perlesnor" aria-label="Perlesnor">
+        <a
+          href="perlesnor.html"
+          target="content"
+          data-label="Perlesnor"
+          aria-label="Perlesnor"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M2 12h20" />
             <circle cx="6" cy="12" r="1.5" />
@@ -615,7 +671,14 @@
         </a>
       </li>
       <li>
-        <a href="kuler.html" target="content" data-label="Kuler" aria-label="Kuler">
+        <a
+          href="kuler.html"
+          target="content"
+          data-label="Kuler"
+          aria-label="Kuler"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M3 11q9 9 18 0" />
             <circle cx="9" cy="13" r="1.5" fill="currentColor" stroke="none" />
@@ -626,7 +689,14 @@
         </a>
       </li>
       <li>
-        <a href="kvikkbilder.html" target="content" data-label="Kvikkbilder" aria-label="Kvikkbilder">
+        <a
+          href="kvikkbilder.html"
+          target="content"
+          data-label="Kvikkbilder"
+          aria-label="Kvikkbilder"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <circle cx="6" cy="8" r="1.5" fill="currentColor" stroke="none" />
             <circle cx="12" cy="8" r="1.5" fill="currentColor" stroke="none" />
@@ -639,7 +709,14 @@
         </a>
       </li>
       <li>
-        <a href="trefigurer.html" target="content" data-label="3D-figurer" aria-label="3D-figurer">
+        <a
+          href="trefigurer.html"
+          target="content"
+          data-label="3D-figurer"
+          aria-label="3D-figurer"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true">
             <path d="M6 6v8c0 2.05 2.686 3.7 6 3.7s6-1.65 6-3.7V6c0 2.05-2.686 3.7-6 3.7S6 8.05 6 6Z" fill="currentColor" fill-opacity=".15" />
             <ellipse cx="12" cy="6" rx="6" ry="3.2" fill="currentColor" fill-opacity=".2" />
@@ -651,7 +728,14 @@
         </a>
       </li>
       <li>
-        <a href="brøkvegg.html" target="content" data-label="Brøkvegg" aria-label="Brøkvegg">
+        <a
+          href="brøkvegg.html"
+          target="content"
+          data-label="Brøkvegg"
+          aria-label="Brøkvegg"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <rect x="4" y="4" width="16" height="4" rx="1.5" fill="currentColor" stroke="none" />
             <rect x="4" y="10" width="16" height="4" rx="1.5" />
@@ -661,7 +745,14 @@
         </a>
       </li>
       <li>
-        <a href="prikktilprikk.html" target="content" data-label="Prikk til prikk (beta)" aria-label="Prikk til prikk (beta)">
+        <a
+          href="prikktilprikk.html"
+          target="content"
+          data-label="Prikk til prikk (beta)"
+          aria-label="Prikk til prikk (beta)"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <line x1="6" y1="18" x2="12" y2="6" stroke-linecap="round" stroke-linejoin="round" />
             <line x1="12" y1="6" x2="18" y2="18" stroke-linecap="round" stroke-linejoin="round" />
@@ -674,7 +765,14 @@
         </a>
       </li>
       <li>
-        <a href="fortegnsskjema.html" target="content" data-label="Fortegnsskjema – under utvikling" aria-label="Fortegnsskjema, under utvikling">
+        <a
+          href="fortegnsskjema.html"
+          target="content"
+          data-label="Fortegnsskjema – under utvikling"
+          aria-label="Fortegnsskjema, under utvikling"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="1.2" aria-hidden="true">
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 7h16" />
             <path stroke-linecap="round" stroke-linejoin="round" d="M20 7l-3-3M20 7l-3 3" />
@@ -686,7 +784,14 @@
         </a>
       </li>
       <li>
-        <a href="tallinje.html" target="content" data-label="Tallinje (beta)" aria-label="Tallinje (beta)">
+        <a
+          href="tallinje.html"
+          target="content"
+          data-label="Tallinje (beta)"
+          aria-label="Tallinje (beta)"
+          data-default-example="1"
+          data-include-example-in-path="true"
+        >
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" aria-hidden="true">
             <line x1="3" y1="12" x2="21" y2="12" stroke-linecap="round" />
             <line x1="7" y1="8" x2="7" y2="16" stroke-linecap="round" />


### PR DESCRIPTION
## Summary
- add default example metadata to all navigation links so the first example is included in the URL path

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e6593d16fc83249fb2b0bbf37d428a