### PR TITLE
Fix graftegner clean-state hydration for persisted canvas height

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -11746,6 +11746,7 @@ function setupSettingsForm() {
       || migrateStorageState({ state: rawState, adv: ADV })
       || migrateStorageState({ adv: ADV });
     if (!normalized) return false;
+    const normalizedExampleState = buildExampleStateFromStorageV2(normalized);
     const loadedCanvasHeight = normalizeCanvasHeight(
       normalized.canvasHeight || (normalized.meta && normalized.meta.canvasHeight)
     );
@@ -11760,6 +11761,10 @@ function setupSettingsForm() {
     if (typeof window !== 'undefined') {
       window.STATE_V2 = normalized;
       window.STATE = normalized;
+    }
+
+    if (normalizedExampleState && EXAMPLE_STATE && typeof EXAMPLE_STATE === 'object') {
+      Object.assign(EXAMPLE_STATE, normalizedExampleState);
     }
 
     const nextCode = typeof normalized.code === 'string' ? normalized.code : '';
@@ -11779,6 +11784,10 @@ function setupSettingsForm() {
       ADV.screen = copy;
       LAST_COMPUTED_SCREEN = copy.slice(0, 4);
       LAST_SCREEN_SOURCE = 'manual';
+      if (EXAMPLE_STATE && typeof EXAMPLE_STATE === 'object') {
+        EXAMPLE_STATE.screen = copy.slice(0, 4);
+        EXAMPLE_STATE.screenSource = 'manual';
+      }
       if (screenInput) {
         screenInput.value = formatScreenForInput(copy);
         screenInput.classList.remove('is-auto');


### PR DESCRIPTION
## Summary
- hydrate `EXAMPLE_STATE` from the loaded v2 clean state inside `loadCleanSaveState`
- ensure restored `view` is mirrored to `EXAMPLE_STATE.screen` and `screenSource`
- keep persisted `canvasHeight` and other example-level settings available after pressing **Oppdater**, preventing fallback/reset behavior during re-load

## Testing
- Not run (static code change only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69941fc2f2dc8324a560eeb9f70938c9)