### PR TITLE
Follow-up: fix chained slash parsing regression in graftegner.js

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -4927,24 +4927,27 @@ function convertNumericFractionsToLatex(input) {
     }
     return { start: signStart, end };
   };
-  let out = input;
-  let idx = out.indexOf('/');
+  let out = '';
+  let cursor = 0;
+  let idx = input.indexOf('/');
   while (idx !== -1) {
-    const left = readLeftOperand(out, idx);
-    const right = readRightOperand(out, idx);
-    if (!left || !right || left.end >= idx || right.start <= idx) {
-      idx = out.indexOf('/', idx + 1);
+    const left = readLeftOperand(input, idx);
+    const right = readRightOperand(input, idx);
+    if (!left || !right || left.end >= idx || right.start <= idx || left.start < cursor) {
+      idx = input.indexOf('/', idx + 1);
       continue;
     }
-    const numerator = out.slice(left.start, left.end + 1).trim();
-    const denominator = out.slice(right.start, right.end + 1).trim();
+    const numerator = input.slice(left.start, left.end + 1).trim();
+    const denominator = input.slice(right.start, right.end + 1).trim();
     if (!numerator || !denominator) {
-      idx = out.indexOf('/', idx + 1);
+      idx = input.indexOf('/', idx + 1);
       continue;
     }
-    out = `${out.slice(0, left.start)}\\frac{${numerator}}{${denominator}}${out.slice(right.end + 1)}`;
-    idx = out.indexOf('/', left.start + 6);
+    out += `${input.slice(cursor, left.start)}\\frac{${numerator}}{${denominator}}`;
+    cursor = right.end + 1;
+    idx = input.indexOf('/', cursor);
   }
+  out += input.slice(cursor);
   return out;
 }
 function convertExpressionToLatex(str) {


### PR DESCRIPTION
### Motivation
- Fix a regression in `convertNumericFractionsToLatex` where inserting `\frac{...}{...}` during processing caused subsequent `/` matches to reparse the generated LaTeX and produce malformed output for chained divisions like `1/2/3`.

### Description
- Reworked the rewrite loop to parse operands from the original `input` and build the result incrementally into `out` using a `cursor`, preventing injected `\frac` text from being scanned.
- Switched `indexOf` usage to operate on `input` (not `out`) and added the guard `left.start < cursor` so already-rewritten regions cannot be re-consumed by later `/` matches.
- Appends the remaining tail with `out += input.slice(cursor)` and keeps the existing operand-reading helpers (`readLeftOperand` / `readRightOperand`) unchanged.

### Testing
- Ran `node --check graftegner.js` with no syntax errors reported.
- Executed inline evaluations of `convertNumericFractionsToLatex` for chained-division cases and observed expected outputs, for example `1/2/3 -> \frac{1}{2}/3`, `x/2/3 -> \frac{x}{2}/3`, `(x+1)/2/3 -> \frac{(x+1)}{2}/3`, and `a/(b+c)/d -> \frac{a}{(b+c)}/d`.
- Verified the function no longer reparses generated `\frac` output for those chained cases.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69943240f2888324be965e274539684c)