### PR TITLE
Fix PNG export to include JSXGraph point labels

### DIFF
--- a/graftegner.js
+++ b/graftegner.js
@@ -8540,7 +8540,9 @@ if (btnSvg) {
         dimensions: { width: svgExport.width, height: svgExport.height },
         htmlTarget,
         backgroundColor: '#fff',
-        pngFallbackOrder: 'svg-first',
+        // HTML-first captures JSXGraph sine HTML-etiketter (f.eks. punktnavn A, B, C, D)
+        // før vi eventuelt faller tilbake til SVG-rendring.
+        pngFallbackOrder: 'html-first',
         svgStringAlreadySanitized: true,
         downloadSvg: true,
         downloadMetadata: false,


### PR DESCRIPTION
### Motivation
- The PNG export sometimes omitted point labels (A, B, C, ...) because those labels are rendered as HTML overlays by JSXGraph and an SVG-first export can miss them. 

### Description
- Change the export fallback order from `svg-first` to `html-first` in `graftegner.js` so `MathVisSvgExport.exportGraphicWithArchive` will try HTML-based rendering first, preserving HTML point labels. 
- Kept the SVG fallback in place so PNG export remains robust when HTML rendering fails. 

### Testing
- Ran `node --check graftegner.js` to validate syntax, which succeeded. 
- Launched a local HTTP server and executed a Playwright script that opened `graftegner.html` and captured a screenshot to verify the exported view, which completed successfully. 
- Manual verification via the export flow was exercised in the Playwright run and confirmed the change behaved as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a06b2099d88324bf6c355281217716)